### PR TITLE
Ignore more venvs in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ __pycache__/
 
 # Distribution / packaging
 .Python
-env/
+/env*/
 build/
 develop-eggs/
 dist/

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ __pycache__/
 
 # Distribution / packaging
 .Python
-/env*/
 build/
 develop-eggs/
 dist/
@@ -60,3 +59,7 @@ target/
 
 #Ipython Notebook
 .ipynb_checkpoints
+
+# virtualenvs
+/env*/
+/.venv*/


### PR DESCRIPTION
It's not uncommon for me to name virtualenvs e.g. `env37` or `env-old`.

Extracted from #52.