### PR TITLE
Fix a crash in sys.version_info check

### DIFF
--- a/pyi.py
+++ b/pyi.py
@@ -294,7 +294,8 @@ class PyiVisitor(ast.NodeVisitor):
             if not isinstance(comparator, ast.Tuple):
                 self.error(node, Y003)
                 return
-            elif not all(isinstance(elt, ast.Num) for elt in comparator.elts):
+
+            if not all(isinstance(elt, ast.Num) for elt in comparator.elts):
                 self.error(node, Y003)
             elif len(comparator.elts) > 2:
                 # mypy only supports major and minor version checks

--- a/pyi.py
+++ b/pyi.py
@@ -293,6 +293,7 @@ class PyiVisitor(ast.NodeVisitor):
         else:
             if not isinstance(comparator, ast.Tuple):
                 self.error(node, Y003)
+                return
             elif not all(isinstance(elt, ast.Num) for elt in comparator.elts):
                 self.error(node, Y003)
             elif len(comparator.elts) > 2:

--- a/tests/sysversioninfo.pyi
+++ b/tests/sysversioninfo.pyi
@@ -30,6 +30,9 @@ if sys.version_info[:2] == (2, 7):
 if sys.version_info[:2] == (2,):  # Y005 Version comparison must be against a length-2 tuple
     ...
 
+if sys.version_info[:2] == "lol":  # Y003 Unrecognized sys.version_info check
+    ...
+
 if sys.version_info[:, :] >= (2, 7):  # Y003 Unrecognized sys.version_info check
     ...
 


### PR DESCRIPTION
This previously caused an `AttributeError`:

```python3
if sys.version_info[:2] == "lol":
    ...
```

It now emits `Y003 Unrecognized sys.version_info check`. I found this when working on a pull request to add mypy to github actions.