### PR TITLE
Create error for sys.version_info[:2.0]

### DIFF
--- a/pyi.py
+++ b/pyi.py
@@ -263,10 +263,14 @@ class PyiVisitor(ast.NodeVisitor):
                 else:
                     self.error(node, Y003)
             elif isinstance(slc, ast.Slice):
-                # allow only [:1] and [:2]
                 if slc.lower is not None or slc.step is not None:
                     self.error(node, Y003)
-                elif isinstance(slc.upper, ast.Num) and slc.upper.n in (1, 2):
+                elif (
+                    # allow only [:1] and [:2]
+                    isinstance(slc.upper, ast.Num)
+                    and isinstance(slc.upper.n, int)
+                    and slc.upper.n in (1, 2)
+                ):
                     can_have_strict_equals = slc.upper.n
                 else:
                     self.error(node, Y003)

--- a/tests/sysversioninfo.pyi
+++ b/tests/sysversioninfo.pyi
@@ -33,6 +33,9 @@ if sys.version_info[:2] == (2,):  # Y005 Version comparison must be against a le
 if sys.version_info[:2] == "lol":  # Y003 Unrecognized sys.version_info check
     ...
 
+if sys.version_info[:2.0] >= (3, 9):  # Y003 Unrecognized sys.version_info check
+    ...
+
 if sys.version_info[:, :] >= (2, 7):  # Y003 Unrecognized sys.version_info check
     ...
 


### PR DESCRIPTION
Previously this was not an error, even though `foo.n in (1, 2)` was clearly intended to guard against this.

This too was discovered with `mypy pyi.py` :)