### PR TITLE
improvements to Assign check

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ Change Log
 unreleased
 ~~~~~~~~~~
 
+* introduce Y093 (require using TypeAlias for type aliases)
+* introduce Y017 (disallows assignments with multiple targets or non-name targets)
+* extend Y001 to cover ParamSpec and TypeVarTuple in addition to TypeVar
 * introduce Y016 (duplicate union member)
 
 20.10.0

--- a/pyi.py
+++ b/pyi.py
@@ -536,4 +536,4 @@ Y091 = 'Y091 Function body must not contain "raise"'
 Y092 = "Y092 Top-level attribute must not have a default value"
 Y093 = "Y093 Use typing_extensions.TypeAlias for type aliases"
 
-DISABLED_BY_DEFAULT = [Y090, Y091, Y092]
+DISABLED_BY_DEFAULT = [Y090, Y091, Y092, Y093]

--- a/tests/aliases.pyi
+++ b/tests/aliases.pyi
@@ -1,0 +1,8 @@
+# flags: --select=Y017,Y093
+from typing import TypeAlias
+
+X = int  # Y093 Use typing_extensions.TypeAlias for type aliases
+X: TypeAlias = int
+
+a = b = int  # Y017 Only simple assignments allowed
+a.b = int  # Y017 Only simple assignments allowed

--- a/tests/typevar.pyi
+++ b/tests/typevar.pyi
@@ -1,4 +1,8 @@
-from typing import TypeVar
+from typing import ParamSpec, TypeVar, TypeVarTuple
 
-T = TypeVar('T')  # Y001 Name of private TypeVar must start with _
-_T = TypeVar('_T')
+T = TypeVar("T")  # Y001 Name of private TypeVar must start with _
+_T = TypeVar("_T")
+P = ParamSpec("P")  # Y001 Name of private ParamSpec must start with _
+_P = ParamSpec("_P")
+Ts = TypeVarTuple("Ts")  # Y001 Name of private TypeVarTuple must start with _
+_Ts = TypeVarTuple("_Ts")


### PR DESCRIPTION
Fixes #44

* introduce Y093 (require using TypeAlias for type aliases)
* introduce Y017 (disallows assignments with multiple targets or non-name targets)
* extend Y001 to cover ParamSpec and TypeVarTuple in addition to TypeVar
