### PR TITLE
Mention 3.10 in the changelog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ unreleased
 ~~~~~~~~~~
 
 * introduce Y016 (duplicate union member)
+* support Python 3.10
 
 20.10.0
 ~~~~~~~


### PR DESCRIPTION
@Akuli already turned on CI and added it to setup.py, but let's mention it in the changelog like we did for 3.9.