### PR TITLE
Drop `attrs` dependency and support for Python 3.6; refactor to use stdlib `dataclasses`

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ unreleased
 * extend Y001 to cover ParamSpec and TypeVarTuple in addition to TypeVar
 * introduce Y016 (duplicate union member)
 * support Python 3.10
+* discontinue support for 3.6
 
 20.10.0
 ~~~~~~~

--- a/pyi.py
+++ b/pyi.py
@@ -3,8 +3,8 @@ import logging
 
 import argparse
 import ast
-import attr
 import sys
+from dataclasses import dataclass, field
 from flake8 import checker  # type: ignore
 from flake8.plugins.pyflakes import FlakesChecker  # type: ignore
 from itertools import chain
@@ -17,7 +17,7 @@ from pyflakes.checker import (  # type: ignore[import]
     ClassScope,
     FunctionScope,
 )
-from typing import Any, Iterable, List, NamedTuple, Optional, Sequence, Type
+from typing import Any, ClassVar, Iterable, List, NamedTuple, Optional, Sequence, Type
 
 __version__ = "20.10.0"
 
@@ -140,12 +140,12 @@ class PyiAwareFileChecker(checker.FileChecker):
         return super().run_check(plugin, **kwargs)
 
 
-@attr.s
+@dataclass
 class PyiVisitor(ast.NodeVisitor):
-    filename = attr.ib(default=Path("(none)"))
-    errors = attr.ib(type=List[Error], default=attr.Factory(list))
-    _class_nesting = attr.ib(default=0)
-    _function_nesting = attr.ib(default=0)
+    filename: Path = Path("(none)")
+    errors: List[Error] = field(default_factory=list)
+    _class_nesting: int = 0
+    _function_nesting: int = 0
 
     @property
     def in_function(self) -> bool:
@@ -292,7 +292,6 @@ class PyiVisitor(ast.NodeVisitor):
                 # Python 3.9 flattens the AST and removes Index, so simulate that here
                 slice_num = slc if isinstance(slc, ast.Num) else slc.value
                 # anything other than the integer 0 doesn't make much sense
-                # (things that are in 2.7 and 3.7 but not 3.6?)
                 if isinstance(slice_num, ast.Num) and slice_num.n == 0:
                     must_be_single = True
                 else:
@@ -438,14 +437,14 @@ class PyiVisitor(ast.NodeVisitor):
         yield from self.errors
 
 
-@attr.s
+@dataclass
 class PyiTreeChecker:
-    name = "flake8-pyi"
-    version = __version__
+    name: ClassVar[str] = "flake8-pyi"
+    version: ClassVar[str] = __version__
 
-    tree = attr.ib(default=None)
-    filename = attr.ib(default="(none)")
-    options = attr.ib(default=None)
+    tree: Optional[ast.Module] = None
+    filename: str = "(none)"
+    options: Any = None
 
     def run(self):
         path = Path(self.filename)

--- a/pyi.py
+++ b/pyi.py
@@ -444,7 +444,7 @@ class PyiTreeChecker:
 
     tree: Optional[ast.Module] = None
     filename: str = "(none)"
-    options: Any = None
+    options: Optional[argparse.Namespace] = None
 
     def run(self):
         path = Path(self.filename)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [bdist_wheel]
-python-tag = py36
+python-tag = py37

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup
 import sys
 
 
-assert sys.version_info >= (3, 6, 0), "flake8-pyi requires Python 3.6+"
+assert sys.version_info >= (3, 7, 0), "flake8-pyi requires Python 3.7+"
 
 
 current_dir = os.path.abspath(os.path.dirname(__file__))
@@ -35,8 +35,8 @@ setup(
     license="MIT",
     py_modules=["pyi"],
     zip_safe=False,
-    python_requires=">=3.6",
-    install_requires=["flake8 >= 3.2.1", "pyflakes >= 2.1.1", "attrs"],
+    python_requires=">=3.7",
+    install_requires=["flake8 >= 3.2.1", "pyflakes >= 2.1.1"],
     test_suite="tests.test_pyi",
     classifiers=[
         "Development Status :: 3 - Alpha",
@@ -46,7 +46,6 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
Refs #63