### PR TITLE
Use ast_decompiler from pypi when ast.unparse isn't available

### DIFF
--- a/pyi.py
+++ b/pyi.py
@@ -22,6 +22,11 @@ from pyflakes.checker import (  # type: ignore[import]
 )
 from typing import ClassVar, NamedTuple
 
+if sys.version_info >= (3, 9):
+    from ast import unparse
+else:
+    from ast_decompiler import decompile as unparse
+
 __version__ = "20.10.0"
 
 LOG = logging.getLogger("flake8.pyi")
@@ -222,11 +227,7 @@ class PyiVisitor(ast.NodeVisitor):
 
         for members in members_by_dump.values():
             if len(members) >= 2:
-                if sys.version_info >= (3, 9):  # ast.unparse() exists
-                    error_string = f'{Y016} "{ast.unparse(members[1])}"'
-                else:
-                    error_string = Y016
-                self.error(members[1], error_string)
+                self.error(members[1], Y016.format(unparse(members[1])))
 
     def visit_BinOp(self, node: ast.BinOp) -> None:
         if not isinstance(node.op, ast.BitOr):
@@ -557,7 +558,7 @@ Y012 = 'Y012 Class body must not contain "pass"'
 Y013 = 'Y013 Non-empty class body must not contain "..."'
 Y014 = 'Y014 Default values for arguments must be "..."'
 Y015 = 'Y015 Attribute must not have a default value other than "..."'
-Y016 = "Y016 Duplicate union member"
+Y016 = 'Y016 Duplicate union member "{}"'
 Y017 = "Y017 Only simple assignments allowed"
 Y018 = 'Y018 {typevarlike_cls} "{typevar_name}" is not used'
 Y092 = "Y092 Top-level attribute must not have a default value"

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     py_modules=["pyi"],
     zip_safe=False,
     python_requires=">=3.7",
-    install_requires=["flake8 >= 3.2.1", "pyflakes >= 2.1.1"],
+    install_requires=["flake8 >= 3.2.1", "pyflakes >= 2.1.1", 'ast-decompiler >= 0.4.0, <0.5.0; python_version < "3.9"'],
     test_suite="tests.test_pyi",
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,11 @@ setup(
     py_modules=["pyi"],
     zip_safe=False,
     python_requires=">=3.7",
-    install_requires=["flake8 >= 3.2.1", "pyflakes >= 2.1.1", 'ast-decompiler >= 0.4.0, <0.5.0; python_version < "3.9"'],
+    install_requires=[
+        "flake8 >= 3.2.1",
+        "pyflakes >= 2.1.1",
+        'ast-decompiler >= 0.4.0, <0.5.0; python_version < "3.9"',
+    ],
     test_suite="tests.test_pyi",
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/tests/test_pyi_files.py
+++ b/tests/test_pyi_files.py
@@ -2,7 +2,6 @@ import glob
 import os
 import re
 import subprocess
-import sys
 
 import pytest
 
@@ -23,14 +22,6 @@ def test_pyi_file(path):
         match = re.search("# ([A-Z][0-9][0-9][0-9].*)", line)
         if match:
             expected_output += f"{path}:{lineno}: {match.group(1)}\n"
-
-    # TODO: is a python version dependent error message really a good idea?
-    if sys.version_info < (3, 9):
-        expected_output = re.sub(
-            r'Y016 Duplicate union member ".*"',
-            "Y016 Duplicate union member",
-            expected_output,
-        )
 
     run_results = [
         # Passing a file on command line


### PR DESCRIPTION
I generally don't like adding dependencies to projects, but I think it's justified in this case:
- The dependency does something nontrivial. It is about 1100 lines of code.
- The dependency is used only with older Python versions.
- We trust the author of the dependency.
- We can do better error messages with the dependency.
- Code is cleaner with the dependency.