### PR TITLE
Introduce Y028: Use class-based syntax for `NamedTuple`s

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ unreleased
 * introduce Y018 (detect unused TypeVars)
 * introduce Y019 (detect TypeVars that should be _typeshed.Self, but aren't)
 * introduce Y016 (duplicate union member)
+* introduce Y028 (Use class-based syntax for NamedTuples)
 * support Python 3.10
 * discontinue support for Python 3.6
 * introduce Y022 (prefer stdlib classes over ``typing`` aliases)

--- a/README.rst
+++ b/README.rst
@@ -91,6 +91,8 @@ currently emitted:
   for more precise type inference.
 * Y025: Always alias ``collections.abc.Set`` when importing it, so as to avoid
   confusion with ``builtins.set``.
+* Y028: Always use class-based syntax for ``typing.NamedTuple``, instead of
+  assignment-based syntax.
 
 The following warnings are disabled by default:
 

--- a/pyi.py
+++ b/pyi.py
@@ -359,7 +359,19 @@ class PyiVisitor(ast.NodeVisitor):
         self.all_name_occurrences[node.id] += 1
 
     def visit_Call(self, node: ast.Call) -> None:
-        self.visit(node.func)
+        function = node.func
+        self.visit(function)
+        if isinstance(function, ast.Name):
+            if function.id == "NamedTuple":
+                return self.error(node, Y028)
+        elif isinstance(function, ast.Attribute):
+            if (
+                isinstance(function.value, ast.Name)
+                and function.value.id == "typing"
+                and function.attr == "NamedTuple"
+            ):
+                return self.error(node, Y028)
+
         # String literals can appear in positional arguments for
         # TypeVar definitions.
         with self.allow_string_literals():
@@ -880,6 +892,7 @@ Y025 = (
     'Y025 Use "from collections.abc import Set as AbstractSet" '
     'to avoid confusion with "builtins.set"'
 )
+Y028 = "Y028 Use class-based syntax for NamedTuples"
 Y093 = "Y093 Use typing_extensions.TypeAlias for type aliases"
 
 DISABLED_BY_DEFAULT = [Y093]

--- a/tests/calls.pyi
+++ b/tests/calls.pyi
@@ -1,0 +1,9 @@
+import typing
+from typing import NamedTuple
+
+T = NamedTuple("T", [('foo', int), ('bar', str)])  # Y028 Use class-based syntax for NamedTuples
+U = typing.NamedTuple("U", [('baz', bytes)])  # Y028 Use class-based syntax for NamedTuples
+
+class V(NamedTuple):
+    foo: int
+    bar: str


### PR DESCRIPTION
Closes #32