### PR TITLE
Make CI timeout longer for pytest

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -45,7 +45,7 @@ jobs:
         flake8 $(git ls-files | grep 'py$')
   tests:
     name: pytest suite
-    timeout-minutes: 5
+    timeout-minutes: 10
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
It doesn't seem to reliably be able to finish in 5 minutes, and it's annoying to have the CI job just get cancelled.