### PR TITLE
Generalise logic keeping track of state

### DIFF
--- a/pyi.py
+++ b/pyi.py
@@ -299,9 +299,9 @@ class PyiVisitor(ast.NodeVisitor):
     # Mapping of each name in the file to the no. of occurrences
     all_name_occurrences: Counter[str] = field(default_factory=Counter)
 
-    string_literals_allowed: NestingCounter = NestingCounter()
-    in_function: NestingCounter = NestingCounter()
-    in_class: NestingCounter = NestingCounter()
+    string_literals_allowed: NestingCounter = field(default_factor=NestingCounter)
+    in_function: NestingCounter = field(default_factory=NestingCounter)
+    in_class: NestingCounter = field(default_factory=NestingCounter)
 
     def _check_import_or_attribute(
         self, node: ast.Attribute | ast.ImportFrom, module_name: str, object_name: str

--- a/pyi.py
+++ b/pyi.py
@@ -299,7 +299,7 @@ class PyiVisitor(ast.NodeVisitor):
     # Mapping of each name in the file to the no. of occurrences
     all_name_occurrences: Counter[str] = field(default_factory=Counter)
 
-    string_literals_allowed: NestingCounter = field(default_factor=NestingCounter)
+    string_literals_allowed: NestingCounter = field(default_factory=NestingCounter)
     in_function: NestingCounter = field(default_factory=NestingCounter)
     in_class: NestingCounter = field(default_factory=NestingCounter)
 

--- a/pyi.py
+++ b/pyi.py
@@ -272,7 +272,7 @@ def _is_bad_TypedDict(node: ast.Call) -> bool:
 
 @dataclass
 class NestingCounter:
-    """Context manager to help the PyiVisitor keep track of internal state"""
+    """Class to help the PyiVisitor keep track of internal state"""
 
     nesting: int = 0
 

--- a/pyi.py
+++ b/pyi.py
@@ -8,7 +8,7 @@ import optparse
 import re
 import sys
 from collections import Counter
-from collections.abc import Iterable, Iterator, Sequence
+from collections.abc import Iterable, Sequence
 from copy import deepcopy
 from dataclasses import dataclass, field
 from itertools import chain


### PR DESCRIPTION
I was working on another PR for this project, and felt the need for another context manager similar to @JelleZijlstra's `allow_string_literals`. I realised that something like the pattern I propose in this PR might be a more extensible and less repetitive solution, so I've separated it out into its own PR.