### PR TITLE
Make `PyiVisitor` a non-dataclass

### DIFF
--- a/pyi.py
+++ b/pyi.py
@@ -303,7 +303,7 @@ class PyiVisitor(ast.NodeVisitor):
         self.in_class = NestingCounter()
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}(filename={self.filename})"
+        return f"{self.__class__.__name__}(filename={self.filename!r})"
 
     def _check_import_or_attribute(
         self, node: ast.Attribute | ast.ImportFrom, module_name: str, object_name: str

--- a/pyi.py
+++ b/pyi.py
@@ -301,7 +301,7 @@ class PyiVisitor(ast.NodeVisitor):
         self.string_literals_allowed = NestingCounter()
         self.in_function = NestingCounter()
         self.in_class = NestingCounter()
-        
+
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(filename={self.filename})"
 

--- a/pyi.py
+++ b/pyi.py
@@ -290,18 +290,20 @@ class NestingCounter:
         return bool(self.nesting)
 
 
-@dataclass
 class PyiVisitor(ast.NodeVisitor):
-    filename: Path = Path("(none)")
-    errors: list[Error] = field(default_factory=list)
-    # Mapping of all private TypeVars/ParamSpecs/TypeVarTuples to the nodes where they're defined
-    typevarlike_defs: dict[TypeVarInfo, ast.Assign] = field(default_factory=dict)
-    # Mapping of each name in the file to the no. of occurrences
-    all_name_occurrences: Counter[str] = field(default_factory=Counter)
-
-    string_literals_allowed: NestingCounter = field(default_factory=NestingCounter)
-    in_function: NestingCounter = field(default_factory=NestingCounter)
-    in_class: NestingCounter = field(default_factory=NestingCounter)
+    def __init__(self, filename: Path = Path("none")) -> None:
+        self.filename = filename
+        self.errors: list[Error] = []
+        # Mapping of all private TypeVars/ParamSpecs/TypeVarTuples to the nodes where they're defined
+        self.typevarlike_defs: dict[TypeVarInfo, ast.Assign] = {}
+        # Mapping of each name in the file to the no. of occurrences
+        self.all_name_occurrences: Counter[str] = Counter()
+        self.string_literals_allowed = NestingCounter()
+        self.in_function = NestingCounter()
+        self.in_class = NestingCounter()
+        
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(filename={self.filename})"
 
     def _check_import_or_attribute(
         self, node: ast.Attribute | ast.ImportFrom, module_name: str, object_name: str

--- a/pyi.py
+++ b/pyi.py
@@ -11,7 +11,7 @@ from collections import Counter
 from collections.abc import Iterable, Iterator, Sequence
 from contextlib import contextmanager
 from copy import deepcopy
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from itertools import chain
 from keyword import iskeyword
 from pathlib import Path


### PR DESCRIPTION
At this point, we have so many fields with `default_factory`s that I feel like using `@dataclass` for `PyiVisitor` is adding boilerplate rather than reducing it. I'm also not convinced that we need the other features of `dataclasses` for this class. We're never comparing two instances of `PyiVisitor`, so we don't need the auto-generated `__eq__` method. And, in my opinion, the auto-generated repr for the class is unnecessarily long:

```python
>>> PyiVisitor()
PyiVisitor(filename=WindowsPath('(none)'), errors=[], typevarlike_defs={}, all_name_occurrences=Counter(), string_literals_allowed=NestingCounter(nesting=0), in_function=NestingCounter(nesting=0), in_class=NestingCounter(nesting=0))
```

^And that repr is just for an "empty" `PyiVisitor`, that hasn't even visited an AST tree yet.