### PR TITLE
Fix tests

### DIFF
--- a/tests/test_pyi_files.py
+++ b/tests/test_pyi_files.py
@@ -28,6 +28,7 @@ def test_pyi_file(path):
             ["flake8", "-j0", *flags, path],
             env={**os.environ, "PYTHONPATH": "."},
             stdout=subprocess.PIPE,
+            shell=True
         ),
         # Passing "-" as the file, and reading from stdin instead
         subprocess.run(
@@ -35,6 +36,7 @@ def test_pyi_file(path):
             env={**os.environ, "PYTHONPATH": "."},
             input=file_contents.encode("utf-8"),
             stdout=subprocess.PIPE,
+            shell=True
         ),
     ]
 

--- a/tests/test_pyi_files.py
+++ b/tests/test_pyi_files.py
@@ -28,7 +28,7 @@ def test_pyi_file(path):
             ["flake8", "-j0", *flags, path],
             env={**os.environ, "PYTHONPATH": "."},
             stdout=subprocess.PIPE,
-            shell=True
+            shell=True,
         ),
         # Passing "-" as the file, and reading from stdin instead
         subprocess.run(
@@ -36,7 +36,7 @@ def test_pyi_file(path):
             env={**os.environ, "PYTHONPATH": "."},
             input=file_contents.encode("utf-8"),
             stdout=subprocess.PIPE,
-            shell=True
+            shell=True,
         ),
     ]
 


### PR DESCRIPTION
I just had to uninstall Python (along with many other programs) from my laptop. After reinstalling Python, for some unknown reason, the tests for flake8-pyi failed on my machine with `FileNotFoundError: [WinError 2] The system cannot find the file specified`.

This appears to be the fix.