### PR TITLE
Improve several error codes so attribute access of names is recognised

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## Unreleased
+
+Bugfixes:
+* fix bugs in several error codes so that e.g. `_T = typing.TypeVar("_T")` is
+  recognised as a `TypeVar` definition (previously only `_T = TypeVar("_T")` was
+  recognised).
+* fix bug where `foo = False` at the module level did not trigger a Y015 error.
+* fix bug where `TypeVar`s were erroneously flagged as unused if they were only used in
+  a `typing.Union` subscript.
+
 ## 22.1.0
 
 * extend Y001 to cover `ParamSpec` and `TypeVarTuple` in addition to `TypeVar`

--- a/pyi.py
+++ b/pyi.py
@@ -252,8 +252,8 @@ def _is_object(node: ast.expr, name: str, *, from_: Container[str]) -> bool:
     """Determine whether `node` is an ast representation of `name`.
 
     Return True if `node` is either:
-    1). Of shape `ast.Name(id=<name>)`
-    2). Or of shape `ast.Attribute(value=ast.Name(id=<parent>), attr=<name>)`,
+    1). Of shape `ast.Name(id=<name>)`, or;
+    2). Of shape `ast.Attribute(value=ast.Name(id=<parent>), attr=<name>)`,
         where <parent> is a string that can be found within the `from_` collection of
         strings.
 

--- a/pyi.py
+++ b/pyi.py
@@ -235,7 +235,7 @@ class LegacyNormalizer(ast.NodeTransformer):
 
 
 def _is_name(node: ast.expr | None, name: str) -> bool:
-    """Return True if `node` is the AST representation of `name`
+    """Return True if `node` is an `ast.Name` node with id `name`
 
     >>> import ast
     >>> node = ast.Name(id="Any")
@@ -249,7 +249,13 @@ _TYPING_MODULES = frozenset({"typing", "typing_extensions"})
 
 
 def _is_object(node: ast.expr, name: str, *, from_: Container[str]) -> bool:
-    """Return True if `node` is the AST representation of `name` accessed as an attrbiute.
+    """Determine whether `node` is an ast representation of `name`.
+
+    Return True if `node` is either:
+    1). Of shape `ast.Name(id=<name>)`
+    2). Or of shape `ast.Attribute(value=ast.Name(id=<parent>), attr=<name>)`,
+        where <parent> is a string that can be found within the `from_` collection of
+        strings.
 
     >>> import ast
     >>> node1 = ast.Name(id="Literal")

--- a/pyi.py
+++ b/pyi.py
@@ -451,7 +451,9 @@ class PyiVisitor(ast.NodeVisitor):
             else:
                 self.error(node, Y001.format(cls_name))
 
-    def _check_assignment_to_function(self, node: ast.Assign, function: ast.expr, object_name: str) -> None:
+    def _check_assignment_to_function(
+        self, node: ast.Assign, function: ast.expr, object_name: str
+    ) -> None:
         if isinstance(function, ast.Name):
             cls_name = function.id
         elif (
@@ -493,9 +495,7 @@ class PyiVisitor(ast.NodeVisitor):
         assignment = node.value
         if isinstance(assignment, ast.Call):
             self._check_assignment_to_function(
-                node=node,
-                function=assignment.func,
-                object_name=target_name
+                node=node, function=assignment.func, object_name=target_name
             )
 
         if isinstance(assignment, (ast.Num, ast.Str, ast.Bytes)):

--- a/tests/aliases.pyi
+++ b/tests/aliases.pyi
@@ -1,7 +1,11 @@
+import typing
+import typing_extensions
 from typing import ParamSpec as _ParamSpec, TypeAlias, TypedDict, _Alias
 
 X = int  # Y026 Use typing_extensions.TypeAlias for type aliases
 X: TypeAlias = int
+Y: typing.TypeAlias = int
+Z: typing_extensions.TypeAlias = int
 
 a = b = int  # Y017 Only simple assignments allowed
 a.b = int  # Y017 Only simple assignments allowed

--- a/tests/classdefs.pyi
+++ b/tests/classdefs.pyi
@@ -1,3 +1,4 @@
+import abc
 from abc import abstractmethod
 
 class Bad:
@@ -7,7 +8,13 @@ class Bad:
 class Good:
     @abstractmethod
     def __str__(self) -> str: ...
-    @abstractmethod
+    @abc.abstractmethod
+    def __repr__(self) -> str: ...
+
+class Fine:
+    @abc.abstractmethod
+    def __str__(self) -> str: ...
+    @abc.abstractmethod
     def __repr__(self) -> str: ...
 
 class AlsoGood(str):

--- a/tests/quotes.pyi
+++ b/tests/quotes.pyi
@@ -1,3 +1,5 @@
+import typing
+import typing_extensions
 from typing import Annotated, Literal, TypeAlias, TypeVar
 
 __all__ = ["f", "g"]
@@ -5,9 +7,9 @@ __all__ = ["f", "g"]
 def f(x: "int"): ...  # Y020 Quoted annotations should never be used in stubs
 def g(x: list["int"]): ...  # Y020 Quoted annotations should never be used in stubs
 _T = TypeVar("_T", bound="int")  # Y020 Quoted annotations should never be used in stubs
-def h(x: Literal["a", "b"], y: Literal["c"], z: _T) -> _T: ...
+def h(w: Literal["a", "b"], x: typing.Literal["c"], y: typing_extensions.Literal["d"], z: _T) -> _T: ...
 
-def i(x: Annotated[int, "lots", "of", "strings"]) -> None:
+def i(x: Annotated[int, "lots", "of", "strings"], b: typing.Annotated[str, "more", "strings"]) -> None:
     """Documented and guaranteed useful."""  # Y021 Docstrings should not be included in stubs
 
 def j() -> "int": ...  # Y020 Quoted annotations should never be used in stubs

--- a/tests/typevar.pyi
+++ b/tests/typevar.pyi
@@ -1,11 +1,13 @@
+import typing
+import typing_extensions
 from typing import Annotated, ParamSpec, TypeVar, TypeVarTuple, Union
 
 from _typeshed import Self
 
 T = TypeVar("T")  # Y001 Name of private TypeVar must start with _
-_T = TypeVar("_T")  # Y018 TypeVar "_T" is not used
+_T = typing.TypeVar("_T")  # Y018 TypeVar "_T" is not used
 P = ParamSpec("P")  # Y001 Name of private ParamSpec must start with _
-_P = ParamSpec("_P")  # Y018 ParamSpec "_P" is not used
+_P = typing_extensions.ParamSpec("_P")  # Y018 ParamSpec "_P" is not used
 Ts = TypeVarTuple("Ts")  # Y001 Name of private TypeVarTuple must start with _
 _Ts = TypeVarTuple("_Ts")  # Y018 TypeVarTuple "_Ts" is not used
 

--- a/tests/union_duplicates.pyi
+++ b/tests/union_duplicates.pyi
@@ -1,3 +1,5 @@
+import typing
+import typing_extensions
 from typing import Union
 
 from typing_extensions import Literal, TypeAlias
@@ -11,11 +13,11 @@ def f5_pipe(x: int | int | None) -> None: ...  # Y016 Duplicate union member "in
 def f1_union(x: Union[int, str]) -> None: ...
 def f2_union(x: Union[int, int]) -> None: ...  # Y016 Duplicate union member "int"
 def f3_union(x: Union[None, int, int]) -> None: ...  # Y016 Duplicate union member "int"
-def f4_union(x: Union[int, None, int]) -> None: ...  # Y016 Duplicate union member "int"
-def f5_union(x: Union[int, int, None]) -> None: ...  # Y016 Duplicate union member "int"
+def f4_union(x: typing.Union[int, None, int]) -> None: ...  # Y016 Duplicate union member "int"
+def f5_union(x: typing.Union[int, int, None]) -> None: ...  # Y016 Duplicate union member "int"
 
-just_literals_subscript_union: Union[Literal[1], Literal[2]]  # Y030 Multiple Literal members in a union. Use a single Literal, e.g. "Literal[1, 2]".
-mixed_subscript_union: Union[str, Literal['foo'], Literal['bar']]  # Y030 Multiple Literal members in a union. Combine them into one, e.g. "Literal['foo', 'bar']".
+just_literals_subscript_union: Union[Literal[1], typing.Literal[2]]  # Y030 Multiple Literal members in a union. Use a single Literal, e.g. "Literal[1, 2]".
+mixed_subscript_union: Union[str, Literal['foo'], typing_extensions.Literal['bar']]  # Y030 Multiple Literal members in a union. Combine them into one, e.g. "Literal['foo', 'bar']".
 just_literals_pipe_union: TypeAlias = Literal[True] | Literal['idk']  # Y030 Multiple Literal members in a union. Use a single Literal, e.g. "Literal[True, 'idk']".
 mixed_pipe_union: TypeAlias = Union[Literal[966], int, Literal['baz']]  # Y030 Multiple Literal members in a union. Combine them into one, e.g. "Literal[966, 'baz']".
 many_literal_members_but_needs_combining: TypeAlias = int | Literal['a', 'b'] | Literal['baz']  # Y030 Multiple Literal members in a union. Combine them into one, e.g. "Literal['a', 'b', 'baz']".


### PR DESCRIPTION
Several error codes had issues due to the fact that the plugin hardcoded names such as `Literal` or `Union` into the logic, but did not consider that a user might access these names via attribute access, e.g. `typing_extensions.Literal` or `typing.Union`. For example, the plugin recognised `X: TypeAlias = int` as a valid type alias, but did not recognise `X: typing.TypeAlias = int` as a valid type alias. It's not standard "typeshed style" to access names in that way, but it's nonetheless valid, so we should probably account for that possibility.

This PR fixes these bugs.