### PR TITLE
Run doctest as part of the pytest suite

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,3 +14,6 @@ warn_redundant_casts = true
 warn_return_any = true
 warn_unreachable = true
 warn_unused_ignores = true
+
+[tool.pytest.ini_options]
+addopts = "--doctest-modules"


### PR DESCRIPTION
There are doctests in the docstrings for the helper functions `_is_name` and `_is_object`; it would be nice to make sure that those don't go out of date.