### PR TITLE
Disable F821 and F822 by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ Features:
 * introduce Y034 (detect common errors where return types are hardcoded, but they
   should use `TypeVar`s instead).
 * introduce Y035 (`__all__` in a stub has the same semantics as at runtime).
+* the plugin now blocks all F821 errors from being reported by
+  flake8/pyflakes. This check does not make sense for `.pyi` files, where names are
+  considered defined if they are annotated, even if they are not actually assigned to.
+  The plugin also now patches flake8 so that it reports F822 in fewer situations, for
+  similar reasons.
 
 ## 22.1.0
 

--- a/tests/__all__.pyi
+++ b/tests/__all__.pyi
@@ -2,6 +2,6 @@ __all__: list[str]  # Y035 "__all__" in a stub file must have a value, as it has
 __all__: list[str] = ["foo", "bar", "baz"]
 __all__ = ["foo", "bar", "baz"]
 
-foo: int = ...
-bar: str = ...
-baz: list[set[bytes]] = ...
+foo: int
+bar: str
+baz: list[set[bytes]]

--- a/tests/definitions.pyi
+++ b/tests/definitions.pyi
@@ -1,0 +1,12 @@
+from typing import TypeAlias
+
+class _SpecialForm: ...
+
+Protocol: _SpecialForm
+class MyProtocol(Protocol): ...
+
+class WorkingSet:
+    def require(self) -> None: ...
+
+working_set: WorkingSet
+require: TypeAlias = working_set.require

--- a/tests/forward_refs.pyi
+++ b/tests/forward_refs.pyi
@@ -2,8 +2,8 @@ from typing import Optional, TypeAlias, Union
 
 MaybeCStr: TypeAlias = Optional[CStr]
 CStr: TypeAlias = Union[C, str]
-__version__: str = ...
-__author__: str = ...
+__version__: str
+__author__: str
 
 def make_default_c() -> C: ...
 


### PR DESCRIPTION
This PR proposes disabling the [troublesome F821 error code](https://github.com/python/typeshed/runs/4833060082?check_suite_focus=true) ("undefined name `name`") by default. It also fixes F822 ("undefined name name in `__all__`") so that variables that are annotated, but not assigned to, are recognised by flake8-pyi as being defined in the file. Implementing these changes will allow us to remove the remaining `= ...`s at the module level in typeshed.

I initially tried to implement this using [the `extend_default_ignore` option](https://github.com/PyCQA/flake8-pyi/issues/125#issuecomment-1018589225) that flake8 provides. However, this was not a good solution. If a user specifies `--per-file-ignore` options in their `.flake8` config file, they will need to manually add F821 or F822 to each subdirectory, as these options override the list of ignored-by-default error codes. Moreover... we're already monkeypatching pyflakes in this plugin, so a little more monkeypatching probably won't hurt _too_ much. Lastly, this solution has the advantage that it _only_ affects how `.py` files are parsed by flake8.