### PR TITLE
Add Y036: check for badly-defined `__(a)exit__` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## Unreleased
+
+Features:
+* Introduce Y036 (check for badly defined `__exit__` and `__aexit__` methods).
+
 ## 22.3.0
 
 Bugfixes:

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ currently emitted:
 | Y033 | Do not use type comments (e.g. `x = ... # type: int`) in stubs, even if the stub supports Python 2. Always use annotations instead (e.g. `x: int`).
 | Y034 | Y034 detects common errors where certain methods are annotated as having a fixed return type, despite returning `self` at runtime. Such methods should be annotated with `_typeshed.Self`. This check looks for:<br><br>&nbsp;&nbsp;**1.**&nbsp;&nbsp;Any in-place BinOp dunder methods (`__iadd__`, `__ior__`, etc.) that do not return `Self`.<br>&nbsp;&nbsp;**2.**&nbsp;&nbsp;`__new__`, `__enter__` and `__aenter__` methods that return the class's name unparameterised.<br>&nbsp;&nbsp;**3.**&nbsp;&nbsp;`__iter__` methods that return `Iterator`, even if the class inherits directly from `Iterator`.<br>&nbsp;&nbsp;**4.**&nbsp;&nbsp;`__aiter__` methods that return `AsyncIterator`, even if the class inherits directly from `AsyncIterator`.<br><br>This check excludes methods decorated with `@overload` or `@abstractmethod`.
 | Y035 | `__all__` in a stub file should always have a value, as `__all__` in a `.pyi` file has identical semantics to `__all__` in a `.py` file. E.g. write `__all__ = ["foo", "bar"]` instead of `__all__: list[str]`.
+| Y036 | Y036 detects common errors in `__exit__` and `__aexit__` methods. For example, the first argument in an `__exit__` method should always be annotated with `type[Exception] | None`.
 
 Many error codes enforce modern conventions, and some cannot yet be used in
 all cases:

--- a/pyi.py
+++ b/pyi.py
@@ -366,8 +366,7 @@ class ExitArgAnalysis(NamedTuple):
 def _analyse_exit_method_arg(node: ast.BinOp) -> ExitArgAnalysis:
     """Return a two-item tuple providing analysis of the annotation of an exit-method arg.
 
-    This function is only called if we already know
-    that `node` is a `BoolOp` and node.op is a `BitOr`.
+    Do not call this function unless `node.op` is already known to be an ast.BitOr().
 
     >>> import ast
     >>> ast_node_for = lambda string: ast.parse(string).body[0].value
@@ -378,6 +377,7 @@ def _analyse_exit_method_arg(node: ast.BinOp) -> ExitArgAnalysis:
     >>> _analyse_exit_method_arg(ast_node_for('None | str'))
     ExitArgAnalysis(is_union_with_None=True, non_None_part=Name(id='str', ctx=Load()))
     """
+    assert isinstance(node.op, ast.BitOr)
     if _is_None(node.left):
         return ExitArgAnalysis(is_union_with_None=True, non_None_part=node.right)
     if _is_None(node.right):

--- a/pyi.py
+++ b/pyi.py
@@ -1086,7 +1086,7 @@ class PyiVisitor(ast.NodeVisitor):
                 f"must have a default value"
             )
 
-        if any(obj is None for obj in all_args.kw_defaults):
+        if None in all_args.kw_defaults:
             error_for_bad_exit_method(
                 f"All keyword-only arguments in an {method_name} method "
                 f"must have a default value"

--- a/pyi.py
+++ b/pyi.py
@@ -1181,7 +1181,7 @@ class PyiVisitor(ast.NodeVisitor):
         if _has_bad_hardcoded_returns(node, classdef=classdef):
             return self._Y034_error(node=node, cls_name=classdef.name)
 
-        if method_name == "__exit__":
+        if method_name in {"__exit__", "__aexit__"}:
             return self._check_exit_method(node=node, method_name=method_name)
 
         if all_args.kwonlyargs:

--- a/pyi.py
+++ b/pyi.py
@@ -353,7 +353,7 @@ class ExitArgAnalysis(NamedTuple):
 
     def __repr__(self) -> str:
         if self.non_None_part is None:
-            none_part_repr = 'None'
+            none_part_repr = "None"
         else:
             none_part_repr = ast.dump(self.non_None_part)
 

--- a/pyi.py
+++ b/pyi.py
@@ -36,7 +36,7 @@ else:
     from ast_decompiler import decompile as unparse
 
 if TYPE_CHECKING:
-    from typing import TypeGuard
+    from typing import Literal, TypeGuard
 
 __version__ = "22.3.0"
 
@@ -260,6 +260,7 @@ def _is_name(node: ast.expr | None, name: str) -> bool:
     return isinstance(node, ast.Name) and node.id == name
 
 
+_is_BaseException = partial(_is_name, name="BaseException")
 _TYPING_MODULES = frozenset({"typing", "typing_extensions"})
 
 
@@ -303,6 +304,82 @@ _is_overload = partial(_is_object, name="overload", from_={"typing"})
 _is_final = partial(_is_object, name="final", from_=_TYPING_MODULES)
 _is_Final = partial(_is_object, name="Final", from_=_TYPING_MODULES)
 _is_Self = partial(_is_object, name="Self", from_=({"_typeshed"} | _TYPING_MODULES))
+_is_TracebackType = partial(_is_object, name="TracebackType", from_={"types"})
+
+
+def _is_type_or_Type(node: ast.expr) -> bool:
+    """
+    >>> import ast
+    >>> ast_node_for = lambda string: ast.parse(string).body[0].value
+    >>> _is_type_or_Type(ast_node_for('type'))
+    True
+    >>> _is_type_or_Type(ast_node_for('Type'))
+    True
+    >>> _is_type_or_Type(ast_node_for('builtins.type'))
+    True
+    >>> _is_type_or_Type(ast_node_for('typing_extensions.Type'))
+    True
+    >>> _is_type_or_Type(ast_node_for('typing.Type'))
+    True
+    """
+    if isinstance(node, ast.Name):
+        return node.id in {"type", "Type"}
+    if isinstance(node, ast.Attribute):
+        node_value = node.value
+        if not isinstance(node_value, ast.Name):
+            return False
+        node_value_id = node_value.id
+        attr = node.attr
+        return (node_value_id == "builtins" and attr == "type") or (
+            node_value_id in _TYPING_MODULES and attr == "Type"
+        )
+    return False
+
+
+def _is_PEP_604_union(node: ast.expr | None) -> TypeGuard[ast.BinOp]:
+    return isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr)
+
+
+def _is_None(node: ast.expr) -> bool:
+    return isinstance(node, ast.Constant) and node.value is None
+
+
+_sentinel = ast.expr()
+
+
+class ExitArgAnalysis(NamedTuple):
+    is_union_with_None: bool
+    non_None_part: ast.expr = _sentinel
+
+    def __repr__(self) -> str:
+        return (
+            f"ExitArgAnalysis("
+            f"is_union_with_None={self.is_union_with_None}, "
+            f"non_None_part={ast.dump(self.non_None_part)}"
+            f")"
+        )
+
+
+def _analyse_exit_method_arg(node: ast.BinOp) -> ExitArgAnalysis:
+    """Return a two-item tuple providing analysis of the annotation of an exit-method arg.
+
+    This function is only called if we already know
+    that `node` is a `BoolOp` and node.op is a `BitOr`.
+
+    >>> import ast
+    >>> ast_node_for = lambda string: ast.parse(string).body[0].value
+    >>> _analyse_exit_method_arg(ast_node_for('int | str'))
+    ExitArgAnalysis(is_union_with_None=False, non_None_part=expr())
+    >>> _analyse_exit_method_arg(ast_node_for('int | None'))
+    ExitArgAnalysis(is_union_with_None=True, non_None_part=Name(id='int', ctx=Load()))
+    >>> _analyse_exit_method_arg(ast_node_for('None | str'))
+    ExitArgAnalysis(is_union_with_None=True, non_None_part=Name(id='str', ctx=Load()))
+    """
+    if _is_None(node.left):
+        return ExitArgAnalysis(is_union_with_None=True, non_None_part=node.right)
+    if _is_None(node.right):
+        return ExitArgAnalysis(is_union_with_None=True, non_None_part=node.left)
+    return ExitArgAnalysis(is_union_with_None=False)
 
 
 def _is_decorated_with_final(
@@ -972,6 +1049,103 @@ class PyiVisitor(ast.NodeVisitor):
             ):
                 self.error(statement, Y013)
 
+    def _check_exit_method(  # noqa: C901
+        self, node: ast.FunctionDef | ast.AsyncFunctionDef, method_name: str
+    ) -> None:
+        all_args = node.args
+        non_kw_only_args = _non_kw_only_args_of(all_args)
+        num_args = len(non_kw_only_args)
+        varargs = all_args.vararg
+
+        def error_for_bad_exit_method(details: str) -> None:
+            self.error(node, Y036.format(method_name=method_name, details=details))
+
+        if num_args < 4:
+            if varargs:
+                varargs_annotation = varargs.annotation
+                if not (
+                    varargs_annotation is None or _is_name(varargs_annotation, "object")
+                ):
+                    error_for_bad_exit_method(
+                        f'Star-args in an {method_name} method should be annotated with "object", '
+                        f'not "{unparse(varargs_annotation)}"'
+                    )
+            else:
+                error_for_bad_exit_method(
+                    f"If there are no star-args, "
+                    f"there should be at least 3 non-keyword-only args "
+                    f'in an {method_name} method (excluding "self")'
+                )
+
+        if len(all_args.defaults) < (num_args - 4):
+            error_for_bad_exit_method(
+                f"All arguments after the first 4 in an {method_name} method "
+                f"must have a default value"
+            )
+
+        if any(obj is None for obj in all_args.kw_defaults):
+            error_for_bad_exit_method(
+                f"All keyword-only arguments in an {method_name} method "
+                f"must have a default value"
+            )
+
+        def error_for_bad_annotation(
+            annotation_node: ast.expr, *, arg_number: Literal[1, 2, 3]
+        ) -> None:
+            exit_arg_descriptions = [
+                ("first", "type[BaseException] | None"),
+                ("second", "BaseException | None"),
+                ("third", "types.TracebackType | None"),
+            ]
+
+            arg_name, correct_annotation = exit_arg_descriptions[arg_number - 1]
+
+            error_msg_details = (
+                f"The {arg_name} arg in an {method_name} method "
+                f'should be annotated with "{correct_annotation}", '
+                f'not "{unparse(annotation_node)}"'
+            )
+
+            error_for_bad_exit_method(details=error_msg_details)
+
+        if num_args >= 2:
+            first_arg_annotation = non_kw_only_args[1].annotation
+            if _is_PEP_604_union(first_arg_annotation):
+                is_union_with_None, non_None_part = _analyse_exit_method_arg(
+                    first_arg_annotation
+                )
+                if not (
+                    is_union_with_None
+                    and isinstance(non_None_part, ast.Subscript)
+                    and _is_type_or_Type(non_None_part.value)
+                    and _is_BaseException(non_None_part.slice)
+                ):
+                    error_for_bad_annotation(first_arg_annotation, arg_number=1)
+            elif first_arg_annotation is not None:
+                error_for_bad_annotation(first_arg_annotation, arg_number=1)
+
+        if num_args >= 3:
+            second_arg_annotation = non_kw_only_args[2].annotation
+            if _is_PEP_604_union(second_arg_annotation):
+                is_union_with_None, non_None_part = _analyse_exit_method_arg(
+                    second_arg_annotation
+                )
+                if not (is_union_with_None and _is_BaseException(non_None_part)):
+                    error_for_bad_annotation(second_arg_annotation, arg_number=2)
+            elif second_arg_annotation is not None:
+                error_for_bad_annotation(second_arg_annotation, arg_number=2)
+
+        if num_args >= 4:
+            third_arg_annotation = non_kw_only_args[3].annotation
+            if _is_PEP_604_union(third_arg_annotation):
+                is_union_with_None, non_None_part = _analyse_exit_method_arg(
+                    third_arg_annotation
+                )
+                if not (is_union_with_None and _is_TracebackType(non_None_part)):
+                    error_for_bad_annotation(third_arg_annotation, arg_number=3)
+            elif third_arg_annotation is not None:
+                error_for_bad_annotation(third_arg_annotation, arg_number=3)
+
     def _Y034_error(
         self, node: ast.FunctionDef | ast.AsyncFunctionDef, cls_name: str
     ) -> None:
@@ -1004,6 +1178,9 @@ class PyiVisitor(ast.NodeVisitor):
         if _has_bad_hardcoded_returns(node, classdef=classdef):
             return self._Y034_error(node=node, cls_name=classdef.name)
 
+        if method_name == "__exit__":
+            return self._check_exit_method(node=node, method_name=method_name)
+
         if all_args.kwonlyargs:
             return
 
@@ -1033,8 +1210,11 @@ class PyiVisitor(ast.NodeVisitor):
         if self.in_class.active:
             classdef = self.current_class_node
             assert classdef is not None
+            method_name = node.name
             if _has_bad_hardcoded_returns(node, classdef=classdef):
                 self._Y034_error(node=node, cls_name=classdef.name)
+            elif method_name == "__aexit__":
+                self._check_exit_method(node=node, method_name=method_name)
         self._visit_function(node)
 
     def _Y019_error(
@@ -1303,3 +1483,4 @@ Y032 = (
 Y033 = 'Y033 Do not use type comments in stubs (e.g. use "x: int" instead of "x = ... # type: int")'
 Y034 = 'Y034 {methods} usually return "self" at runtime. Consider using "_typeshed.Self" in "{method_name}", e.g. "{suggested_syntax}"'
 Y035 = 'Y035 "__all__" in a stub file must have a value, as it has the same semantics as "__all__" at runtime.'
+Y036 = "Y036 Badly defined {method_name} method: {details}"

--- a/pyi.py
+++ b/pyi.py
@@ -341,7 +341,10 @@ def _is_PEP_604_union(node: ast.expr | None) -> TypeGuard[ast.BinOp]:
 
 
 def _is_None(node: ast.expr) -> bool:
-    return isinstance(node, ast.Constant) and node.value is None
+    # <=3.7: `BaseException | None` parses as BinOp(left=Name(id='BaseException'), op=BitOr(), right=NameConstant(value=None))`
+    # >=3.8: `BaseException | None` parses as BinOp(left=Name(id='BaseException'), op=BitOr(), right=Constant(value=None))`
+    # ast.NameConstant is deprecated in 3.8+, but doesn't raise a DeprecationWarning (and the isinstance() check still works)
+    return isinstance(node, ast.NameConstant) and node.value is None
 
 
 _sentinel = ast.expr()

--- a/pyi.py
+++ b/pyi.py
@@ -368,7 +368,7 @@ class ExitArgAnalysis(NamedTuple):
 def _analyse_exit_method_arg(node: ast.BinOp) -> ExitArgAnalysis:
     """Return a two-item tuple providing analysis of the annotation of an exit-method arg.
 
-    Do not call this function unless `node.op` is already known to be an ast.BitOr().
+    The `node` represents a union type written as `X | Y`.
 
     >>> import ast
     >>> ast_node_for = lambda string: ast.parse(string).body[0].value

--- a/tests/exit_methods.pyi
+++ b/tests/exit_methods.pyi
@@ -1,0 +1,45 @@
+import types
+import typing
+from types import TracebackType
+from typing import (  # Y022 Use "type[MyClass]" instead of "typing.Type[MyClass]" (PEP 585 syntax)
+    Any,
+    Type,
+)
+
+import typing_extensions
+
+# Good __(a)exit__ methods
+class One:
+    def __exit__(self, *args: object) -> None: ...
+    async def __aexit__(self, *args) -> str: ...
+
+class Two:
+    def __exit__(self, typ: type[BaseException] | None, *args: object) -> bool | None: ...
+    async def __aexit__(self, typ: Type[BaseException] | None, *args: object) -> bool: ...
+
+class Three:
+    def __exit__(self, __typ: typing.Type[BaseException] | None, exc: BaseException | None, *args: object) -> None: ...  # Y022 Use "type[MyClass]" instead of "typing.Type[MyClass]" (PEP 585 syntax)
+    async def __aexit__(self, typ: typing_extensions.Type[BaseException] | None, __exc: BaseException | None, *args: object) -> None: ...  # Y022 Use "type[MyClass]" instead of "typing_extensions.Type[MyClass]" (PEP 585 syntax)
+
+class Four:
+    def __exit__(self, typ: type[BaseException] | None, exc: BaseException | None, tb: TracebackType | None) -> None: ...
+    async def __aexit__(self, typ: type[BaseException] | None, exc: BaseException | None, tb: types.TracebackType | None, *args: list[None]) -> None: ...
+
+class Five:
+    def __exit__(self, typ: type[BaseException] | None, exc: BaseException | None, tb: TracebackType | None, weird_extra_arg: int = ..., *args: int, **kwargs: str) -> None: ...
+
+# Bad __(a)exit__ methods
+class Six:
+    def __exit__(self, *args: Any) -> None: ...  # Y036 Badly defined __exit__ method: Star-args in an __exit__ method should be annotated with "object", not "Any"
+    async def __aexit__(self) -> None: ...  # Y036 Badly defined __aexit__ method: If there are no star-args, there should be at least 3 non-keyword-only args in an __aexit__ method (excluding "self")
+
+class Seven:
+    def __exit__(self, typ, exc, tb, weird_extra_arg) -> None: ...  # Y036 Badly defined __exit__ method: All arguments after the first 4 in an __exit__ method must have a default value
+    async def __aexit__(self, typ, exc, tb, *, weird_extra_arg) -> None: ...  # Y036 Badly defined __aexit__ method: All keyword-only arguments in an __aexit__ method must have a default value
+
+class Eight:
+    def __exit__(self, typ: type[BaseException], exc: BaseException | None, tb: TracebackType | None) -> None: ...  # Y036 Badly defined __exit__ method: The first arg in an __exit__ method should be annotated with "type[BaseException] | None", not "type[BaseException]"
+    async def __aexit__(self, __typ: type[BaseException] | None, __exc: BaseException, __tb: TracebackType) -> bool | None: ...  # Y036 Badly defined __aexit__ method: The second arg in an __aexit__ method should be annotated with "BaseException | None", not "BaseException"  # Y036 Badly defined __aexit__ method: The third arg in an __aexit__ method should be annotated with "types.TracebackType | None", not "TracebackType"
+
+class Nine:
+    def __exit__(self, typ: BaseException | None, *args: list[str]) -> bool: ...  # Y036 Badly defined __exit__ method: Star-args in an __exit__ method should be annotated with "object", not "list[str]"  # Y036 Badly defined __exit__ method: The first arg in an __exit__ method should be annotated with "type[BaseException] | None", not "BaseException | None"

--- a/tests/exit_methods.pyi
+++ b/tests/exit_methods.pyi
@@ -3,6 +3,7 @@ import typing
 from types import TracebackType
 from typing import (  # Y022 Use "type[MyClass]" instead of "typing.Type[MyClass]" (PEP 585 syntax)
     Any,
+    Awaitable,
     Type,
 )
 
@@ -27,6 +28,7 @@ class Four:
 
 class Five:
     def __exit__(self, typ: type[BaseException] | None, exc: BaseException | None, tb: TracebackType | None, weird_extra_arg: int = ..., *args: int, **kwargs: str) -> None: ...
+    def __aexit__(self, typ: type[BaseException] | None, exc: BaseException | None, tb: TracebackType | None) -> Awaitable[None]: ...
 
 # Bad __(a)exit__ methods
 class Six:
@@ -43,3 +45,4 @@ class Eight:
 
 class Nine:
     def __exit__(self, typ: BaseException | None, *args: list[str]) -> bool: ...  # Y036 Badly defined __exit__ method: Star-args in an __exit__ method should be annotated with "object", not "list[str]"  # Y036 Badly defined __exit__ method: The first arg in an __exit__ method should be annotated with "type[BaseException] | None", not "BaseException | None"
+    def __aexit__(self, *args: Any) -> Awaitable[None]: ...  # Y036 Badly defined __aexit__ method: Star-args in an __aexit__ method should be annotated with "object", not "Any"


### PR DESCRIPTION
Fixes #188