### PR TITLE
Introduce Y037: Check for redundant `bytes`/`bytearray` unions, etc.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Features:
 * Introduce Y036 (check for badly defined `__exit__` and `__aexit__` methods).
+* Introduce Y037 (`bytearray` and `memoryview` are redundant in unions with `bytes`)
 
 ## 22.3.0
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ currently emitted:
 | Y034 | Y034 detects common errors where certain methods are annotated as having a fixed return type, despite returning `self` at runtime. Such methods should be annotated with `_typeshed.Self`. This check looks for:<br><br>&nbsp;&nbsp;**1.**&nbsp;&nbsp;Any in-place BinOp dunder methods (`__iadd__`, `__ior__`, etc.) that do not return `Self`.<br>&nbsp;&nbsp;**2.**&nbsp;&nbsp;`__new__`, `__enter__` and `__aenter__` methods that return the class's name unparameterised.<br>&nbsp;&nbsp;**3.**&nbsp;&nbsp;`__iter__` methods that return `Iterator`, even if the class inherits directly from `Iterator`.<br>&nbsp;&nbsp;**4.**&nbsp;&nbsp;`__aiter__` methods that return `AsyncIterator`, even if the class inherits directly from `AsyncIterator`.<br><br>This check excludes methods decorated with `@overload` or `@abstractmethod`.
 | Y035 | `__all__` in a stub file should always have a value, as `__all__` in a `.pyi` file has identical semantics to `__all__` in a `.py` file. E.g. write `__all__ = ["foo", "bar"]` instead of `__all__: list[str]`.
 | Y036 | Y036 detects common errors in `__exit__` and `__aexit__` methods. For example, the first argument in an `__exit__` method should always be annotated with `type[Exception] | None`.
+| Y037 | `bytearray` and `memoryview` are treated as subtypes of `bytes` by type-checkers. This means that it is redundant to annotate variables with unions such as `bytes \| bytearray \| memoryview` (just use `bytes` instead).
 
 Many error codes enforce modern conventions, and some cannot yet be used in
 all cases:

--- a/pyi.py
+++ b/pyi.py
@@ -802,6 +802,15 @@ class PyiVisitor(ast.NodeVisitor):
 
         if not dupes_in_union:
             self._check_for_multiple_literals(members)
+            self._check_for_bytestring_members(members)
+
+    def _check_for_bytestring_members(self, members: Sequence[ast.expr]) -> None:
+        union_names = {member.id for member in members if isinstance(member, ast.Name)}
+
+        if "bytes" in union_names:
+            for cls in ("memoryview", "bytearray"):
+                if cls in union_names:
+                    self.error(members[0], Y037.format(cls=cls))
 
     def _check_for_multiple_literals(self, members: Sequence[ast.expr]) -> None:
         literals_in_union, non_literals_in_union = [], []
@@ -1480,3 +1489,4 @@ Y033 = 'Y033 Do not use type comments in stubs (e.g. use "x: int" instead of "x 
 Y034 = 'Y034 {methods} usually return "self" at runtime. Consider using "_typeshed.Self" in "{method_name}", e.g. "{suggested_syntax}"'
 Y035 = 'Y035 "__all__" in a stub file must have a value, as it has the same semantics as "__all__" at runtime.'
 Y036 = "Y036 Badly defined {method_name} method: {details}"
+Y037 = 'Y037 "{cls}" is redundant in a union with "bytes"'

--- a/tests/union_duplicates.pyi
+++ b/tests/union_duplicates.pyi
@@ -21,3 +21,7 @@ mixed_subscript_union: Union[str, Literal['foo'], typing_extensions.Literal['bar
 just_literals_pipe_union: TypeAlias = Literal[True] | Literal['idk']  # Y030 Multiple Literal members in a union. Use a single Literal, e.g. "Literal[True, 'idk']".
 mixed_pipe_union: TypeAlias = Union[Literal[966], int, Literal['baz']]  # Y030 Multiple Literal members in a union. Combine them into one, e.g. "Literal[966, 'baz']".
 many_literal_members_but_needs_combining: TypeAlias = int | Literal['a', 'b'] | Literal['baz']  # Y030 Multiple Literal members in a union. Combine them into one, e.g. "Literal['a', 'b', 'baz']".
+
+foo: bytes | bytearray  # Y037 "bytearray" is redundant in a union with "bytes"
+bar: bytes | memoryview  # Y037 "memoryview" is redundant in a union with "bytes"
+baz: Union[bytes, bytearray, memoryview]  # Y037 "memoryview" is redundant in a union with "bytes"  # Y037 "bytearray" is redundant in a union with "bytes"


### PR DESCRIPTION
Closes #190