### PR TITLE
Reduce false-positives emitted from Y026 `TypeAlias` check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Behaviour changes:
 * Expand Y035 to cover `__match_args__` inside class definitions, as well as `__all__`
   in the global scope.
 
+Bugfixes:
+* Improve Y026 check (regarding `typing.TypeAlias`) to reduce false-positive errors
+  emitted when the plugin encountered variable aliases in a stub file.
+
 ## 22.3.0
 
 Bugfixes:

--- a/pyi.py
+++ b/pyi.py
@@ -3,10 +3,13 @@ from __future__ import annotations
 
 import argparse
 import ast
+import builtins
+import collections.abc
 import logging
 import optparse
 import re
 import sys
+import typing
 from collections import Counter
 from collections.abc import Container, Iterable, Iterator, Sequence
 from contextlib import contextmanager
@@ -16,6 +19,7 @@ from functools import partial
 from itertools import chain
 from keyword import iskeyword
 from pathlib import Path
+from types import ModuleType
 from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple
 
 from flake8 import checker  # type: ignore[import]
@@ -548,6 +552,16 @@ def _is_assignment_which_must_have_a_value(
     )
 
 
+def _is_probably_class_from_module(var: str, *, module: ModuleType) -> bool:
+    """
+    >>> _is_probably_class_from_module("AbstractSet", module=typing)
+    True
+    >>> _is_probably_class_from_module("int", module=builtins)
+    True
+    """
+    return isinstance(getattr(module, var, object()), (type, type(typing.List)))
+
+
 @dataclass
 class NestingCounter:
     """Class to help the PyiVisitor keep track of internal state"""
@@ -574,6 +588,11 @@ class PyiVisitor(ast.NodeVisitor):
         self.errors: list[Error] = []
         # Mapping of all private TypeVars/ParamSpecs/TypeVarTuples to the nodes where they're defined
         self.typevarlike_defs: dict[TypeVarInfo, ast.Assign] = {}
+        # Mapping of all assignments in the file that could be type aliases
+        # (This excludes assignments to function calls and ellipses, etc.)
+        self.maybe_typealias_assignments: dict[str, ast.Assign] = {}
+        # Set of all names and attributes that are used as annotations in the file
+        self.all_annotations: set[str] = set()
         # Mapping of each name in the file to the no. of occurrences
         self.all_name_occurrences: Counter[str] = Counter()
         self.string_literals_allowed = NestingCounter()
@@ -743,12 +762,54 @@ class PyiVisitor(ast.NodeVisitor):
         ):
             return self._Y015_error(node)
 
-        # We avoid triggering Y026 for calls and = ... because there are various
-        # unusual cases where assignment to the result of a call is legitimate
-        # in stubs.
-        if not is_special_assignment and not isinstance(
-            assignment, (ast.Ellipsis, ast.Call)
-        ):
+        if not is_special_assignment:
+            self._check_for_type_aliases(node, target_name, assignment)
+
+    def _check_for_type_aliases(
+        self, node: ast.Assign, target_name: str, assignment: ast.expr
+    ) -> None:
+        """
+        Check for assignments that look like they could be type aliases,
+        but aren't annotated with `typing(_extensions).TypeAlias`.
+
+        We avoid triggering Y026 for calls and = ... because there are various
+        unusual cases where assignment to the result of a call is legitimate
+        in stubs (`T = TypeVar("T")`, `List = _Alias()`, etc.).
+
+        Most assignments to names in builtins.py or typing.py will be type aliases,
+        so special-case those. For other `ast.Attribute` and `ast.Name` nodes,
+        avoid triggering Y026 now, as they might be variable aliases rather than
+        type aliases.
+        """
+        if isinstance(assignment, (ast.Ellipsis, ast.Call)):
+            return
+
+        special_cased_modules = {builtins, typing, collections.abc}
+
+        if isinstance(assignment, ast.Attribute):
+            if isinstance(assignment.value, ast.Name):
+                module_name, assignment_name = assignment.value.id, assignment.attr
+                for module in special_cased_modules:
+                    if module_name == module.__name__:
+                        if assignment_name in dir(
+                            module
+                        ) and _is_probably_class_from_module(
+                            assignment_name, module=module
+                        ):
+                            self.error(node, Y026)
+                        break
+                else:
+                    self.maybe_typealias_assignments[target_name] = node
+        elif isinstance(assignment, ast.Name):
+            assignment_name = assignment.id
+            for module in special_cased_modules:
+                if assignment_name in dir(module):
+                    if _is_probably_class_from_module(assignment_name, module=module):
+                        self.error(node, Y026)
+                    break
+            else:
+                self.maybe_typealias_assignments[target_name] = node
+        else:
             self.error(node, Y026)
 
     def visit_Name(self, node: ast.Name) -> None:
@@ -792,7 +853,9 @@ class PyiVisitor(ast.NodeVisitor):
             self.generic_visit(node)
 
     def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
-        if _is_Final(node.annotation):
+        annotation = node.annotation
+        self.all_annotations.add(unparse(annotation))
+        if _is_Final(annotation):
             with self.string_literals_allowed.enabled():
                 self.generic_visit(node)
             return
@@ -808,7 +871,7 @@ class PyiVisitor(ast.NodeVisitor):
                     self.error(node, Y035.format(var=target_name))
                 return
         self.generic_visit(node)
-        if _is_TypeAlias(node.annotation):
+        if _is_TypeAlias(annotation):
             return
         if node.value and not isinstance(node.value, ast.Ellipsis):
             self._Y015_error(node)
@@ -1380,6 +1443,9 @@ class PyiVisitor(ast.NodeVisitor):
                     def_node,
                     Y018.format(typevarlike_cls=cls_name, typevar_name=typevar_name),
                 )
+        for annotation in self.all_annotations:
+            if annotation in self.maybe_typealias_assignments:
+                self.error(self.maybe_typealias_assignments[annotation], Y026)
         yield from self.errors
 
 

--- a/tests/aliases.pyi
+++ b/tests/aliases.pyi
@@ -1,8 +1,14 @@
-from collections.abc import Mapping
 import builtins
 import collections
 import typing
-from typing import ParamSpec as _ParamSpec, TypeAlias, TypedDict, Union, _Alias  # Y037 Use PEP 604 union types instead of typing.Union (e.g. "int | str" instead of "Union[int, str]").
+from collections.abc import Mapping
+from typing import (  # Y037 Use PEP 604 union types instead of typing.Union (e.g. "int | str" instead of "Union[int, str]").
+    ParamSpec as _ParamSpec,
+    TypeAlias,
+    TypedDict,
+    Union,
+    _Alias,
+)
 
 import typing_extensions
 

--- a/tests/aliases.pyi
+++ b/tests/aliases.pyi
@@ -1,9 +1,18 @@
+from collections.abc import Mapping
+import builtins
+import collections
 import typing
-from typing import ParamSpec as _ParamSpec, TypeAlias, TypedDict, _Alias
+from typing import ParamSpec as _ParamSpec, TypeAlias, TypedDict, Union, _Alias  # Y037 Use PEP 604 union types instead of typing.Union (e.g. "int | str" instead of "Union[int, str]").
 
 import typing_extensions
 
+T = builtins.str  # Y026 Use typing_extensions.TypeAlias for type aliases
+U = typing.AbstractSet  # Y026 Use typing_extensions.TypeAlias for type aliases
+V = Mapping  # Y026 Use typing_extensions.TypeAlias for type aliases
 X = int  # Y026 Use typing_extensions.TypeAlias for type aliases
+Y = int | str  # Y026 Use typing_extensions.TypeAlias for type aliases
+Z = Union[str, bytes]  # Y026 Use typing_extensions.TypeAlias for type aliases
+
 X: TypeAlias = int
 Y: typing.TypeAlias = int
 Z: typing_extensions.TypeAlias = int
@@ -15,3 +24,17 @@ _P = _ParamSpec("_P")
 List = _Alias()
 
 TD = TypedDict("TD", {"in": bool})
+
+def foo() -> None: ...
+alias_for_foo_but_not_type_alias = foo
+
+alias_for_function_from_builtins = dir
+
+class Foo:
+    def baz(self) -> None: ...
+
+f: Foo = ...
+baz = f.baz
+
+typealias_for_deque = collections.deque  # Y026 Use typing_extensions.TypeAlias for type aliases
+uses_typealias_for_deque_in_annotation: typealias_for_deque

--- a/tests/aliases.pyi
+++ b/tests/aliases.pyi
@@ -1,7 +1,4 @@
-import builtins
-import collections
 import typing
-from collections.abc import Mapping
 from typing import (  # Y037 Use PEP 604 union types instead of typing.Union (e.g. "int | str" instead of "Union[int, str]").
     ParamSpec as _ParamSpec,
     TypeAlias,
@@ -11,17 +8,22 @@ from typing import (  # Y037 Use PEP 604 union types instead of typing.Union (e.
 )
 
 import typing_extensions
+from typing_extensions import Literal
 
-T = builtins.str  # Y026 Use typing_extensions.TypeAlias for type aliases
-U = typing.AbstractSet  # Y026 Use typing_extensions.TypeAlias for type aliases
-V = Mapping  # Y026 Use typing_extensions.TypeAlias for type aliases
-X = int  # Y026 Use typing_extensions.TypeAlias for type aliases
+U = typing.Literal["ham", "bacon"]  # Y026 Use typing_extensions.TypeAlias for type aliases
+V = Literal["spam", "eggs"]  # Y026 Use typing_extensions.TypeAlias for type aliases
+X = typing_extensions.Literal["foo", "bar"]  # Y026 Use typing_extensions.TypeAlias for type aliases
 Y = int | str  # Y026 Use typing_extensions.TypeAlias for type aliases
 Z = Union[str, bytes]  # Y026 Use typing_extensions.TypeAlias for type aliases
 
-X: TypeAlias = int
-Y: typing.TypeAlias = int
-Z: typing_extensions.TypeAlias = int
+A: typing.TypeAlias = typing.Literal["ham", "bacon"]
+B: typing_extensions.TypeAlias = Literal["spam", "eggs"]
+C: TypeAlias = typing_extensions.Literal["foo", "bar"]
+D: TypeAlias = int | str
+E: TypeAlias = Union[str, bytes]
+F: TypeAlias = int
+G: typing.TypeAlias = int
+H: typing_extensions.TypeAlias = int
 
 a = b = int  # Y017 Only simple assignments allowed
 a.b = int  # Y017 Only simple assignments allowed
@@ -41,6 +43,3 @@ class Foo:
 
 f: Foo = ...
 baz = f.baz
-
-typealias_for_deque = collections.deque  # Y026 Use typing_extensions.TypeAlias for type aliases
-uses_typealias_for_deque_in_annotation: typealias_for_deque

--- a/tests/attribute_annotations.pyi
+++ b/tests/attribute_annotations.pyi
@@ -14,7 +14,7 @@ field7 = b""  # Y015 Bad default value. Use "field7 = ..." instead of "field7 = 
 field8 = False  # Y015 Bad default value. Use "field8 = ..." instead of "field8 = False"
 
 # We don't want this one to trigger Y015 -- it's valid as a TypeAlias
-field9 = None    # Y026 Use typing_extensions.TypeAlias for type aliases
+field9 = None
 field10: TypeAlias = None
 
 # Tests for Final

--- a/tests/quotes.pyi
+++ b/tests/quotes.pyi
@@ -5,7 +5,7 @@ from typing import Annotated, Literal, TypeAlias, TypeVar
 import typing_extensions
 
 __all__ = ["f", "g"]
-__match_args__ = ('foo',)  # Y026 Use typing_extensions.TypeAlias for type aliases  # Y020 Quoted annotations should never be used in stubs
+__match_args__ = ('foo',)  # Y020 Quoted annotations should never be used in stubs
 
 def f(x: "int"): ...  # Y020 Quoted annotations should never be used in stubs
 def g(x: list["int"]): ...  # Y020 Quoted annotations should never be used in stubs
@@ -21,7 +21,7 @@ Alias: TypeAlias = list["int"]  # Y020 Quoted annotations should never be used i
 class Child(list["int"]):  # Y020 Quoted annotations should never be used in stubs
     """Documented and guaranteed useful."""  # Y021 Docstrings should not be included in stubs
 
-    __all__ = ('foo',)  # Y026 Use typing_extensions.TypeAlias for type aliases  # Y020 Quoted annotations should never be used in stubs
+    __all__ = ('foo',)  # Y020 Quoted annotations should never be used in stubs
     __match_args__ = ('foo', 'bar')
 
 if sys.platform == "linux":


### PR DESCRIPTION
Fixes #205.

I've temporarily renamed the check from Y026 to Y038 so that I can see the impact using typeshed_primer in CI. I'll revert the renaming once the CI has completed.

(EDIT: The output looked good, so I reverted the renaming.)