### PR TITLE
Prepare for release 22.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## Unreleased
+## 22.4.0
 
 Features:
 * Introduce Y036 (check for badly defined `__exit__` and `__aexit__` methods).

--- a/pyi.py
+++ b/pyi.py
@@ -38,7 +38,7 @@ else:
 if TYPE_CHECKING:
     from typing import Literal, TypeGuard
 
-__version__ = "22.3.0"
+__version__ = "22.4.0"
 
 LOG = logging.getLogger("flake8.pyi")
 


### PR DESCRIPTION
(I'd like to make a release so that we can enable Y026 in typeshed's `.flake8` config file, and have a regression test for https://github.com/python/typeshed/pull/7630)