### PR TITLE
Forbid imports of `collections.abc` aliases from `typing`

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -16,10 +16,6 @@
 #       E701 multiple statements on one line (colon) -- disallows "..." on the same line
 #       E704 multiple statements on one line (def) -- disallows function body on the same line as the def
 #
-# tests/imports.pyi adds the following ignore codes for that specific file:
-#       F401 module imported but unused
-#       F811 redefinition of unused name
-#
 # tests/type_comments.pyi adds the following ignore codes for that specific file:
 #       F723 syntax error in type comment
 #       E261 at least two spaces before inline comment
@@ -32,5 +28,4 @@ select = B,C,E,F,W,Y,B9
 per-file-ignores =
   *.py: E203, E501, W503, W291, W293
   *.pyi: E301, E302, E305, E501, E701, E704, W503
-  tests/imports.pyi: E301, E302, E305, E501, E701, E704, F401, F811, W503
   tests/type_comments.pyi: E261, E262, E301, E302, E305, E501, E701, E704, F723, W503

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+Features:
+* Expand Y027 check to prohibit importing any objects from the `typing` module that are
+  aliases for objects living `collections.abc` (except for `typing.AbstractSet`, which
+  is special-cased).
+* Introduce Y038: Use `from collections.abc import Set as AbstractSet` instead of
+  `from typing import AbstractSet`.
+
 Bugfixes:
 * Improve inaccurate error messages for Y036.
 

--- a/README.md
+++ b/README.md
@@ -69,11 +69,12 @@ currently emitted:
 | Y035 | `__all__` and `__match_args__` in a stub file should always have values, as these special variables in a `.pyi` file have identical semantics to `__all__` and `__match_args__` in a `.py` file. E.g. write `__all__ = ["foo", "bar"]` instead of `__all__: list[str]`.
 | Y036 | Y036 detects common errors in `__exit__` and `__aexit__` methods. For example, the first argument in an `__exit__` method should either be annotated with `object` or `type[BaseException] \| None`.
 | Y037 | Use PEP 604 syntax instead of `typing.Union` and `typing.Optional`. E.g. use `str \| int` instead of `Union[str, int]`, and use `str \| None` instead of `Optional[str]`.
+| Y038 | Use `from collections.abc import Set as AbstractSet` instead of `from typing import AbstractSet`. Like Y027, this error code should be switched off in your config file if your stubs support Python 2.
 
 Many error codes enforce modern conventions, and some cannot yet be used in
 all cases:
 
-* Y027 is incompatible with Python 2 and should only be used in stubs
+* Y027 and Y038 are incompatible with Python 2. These should only be used in stubs
   that are meant only for Python 3.
 * Y037 (enforcing PEP 604 syntax everywhere) is not yet fully compatible with
   the mypy type checker, which has

--- a/pyi.py
+++ b/pyi.py
@@ -111,7 +111,7 @@ _BAD_TYPING_Y023_IMPORTS = frozenset(
         "overload",
         "Text",
         "NoReturn",
-        # ClassVar deliberately omitted, as it's the only one in this group that shouldn't be parameterised
+        # ClassVar deliberately omitted, as it's the only one in this group that should be parameterised
         # It is special-case elsewhere
     }
 )

--- a/pyi.py
+++ b/pyi.py
@@ -111,7 +111,7 @@ _BAD_TYPING_Y023_IMPORTS = frozenset(
         "overload",
         "Text",
         "NoReturn",
-        # ClassVar deliberately omitted, as it's the only one that shouldn't be parameterised
+        # ClassVar deliberately omitted, as it's the only one in this group that shouldn't be parameterised
         # It is special-case elsewhere
     }
 )

--- a/tests/classdefs.pyi
+++ b/tests/classdefs.pyi
@@ -2,9 +2,9 @@ import abc
 import collections.abc
 import typing
 from abc import abstractmethod
-from typing import Any, AsyncIterator, Iterator, overload
+from collections.abc import AsyncIterator, Iterator
+from typing import Any, overload
 
-import typing_extensions
 from _typeshed import Self
 from typing_extensions import final
 
@@ -69,14 +69,14 @@ class InvalidButPluginDoesNotCrash:
 class BadIterator1(Iterator[int]):
     def __iter__(self) -> Iterator[int]: ...  # Y034 "__iter__" methods in classes like "BadIterator1" usually return "self" at runtime. Consider using "_typeshed.Self" in "BadIterator1.__iter__", e.g. "def __iter__(self: Self) -> Self: ..."
 
-class BadIterator2(typing.Iterator[int]):
+class BadIterator2(typing.Iterator[int]):  # Y027 Use "collections.abc.Iterator[T]" instead of "typing.Iterator[T]" (PEP 585 syntax)
     def __iter__(self) -> Iterator[int]: ...  # Y034 "__iter__" methods in classes like "BadIterator2" usually return "self" at runtime. Consider using "_typeshed.Self" in "BadIterator2.__iter__", e.g. "def __iter__(self: Self) -> Self: ..."
 
-class BadIterator3(typing_extensions.Iterator[int]):
+class BadIterator3(typing.Iterator[int]):  # Y027 Use "collections.abc.Iterator[T]" instead of "typing.Iterator[T]" (PEP 585 syntax)
     def __iter__(self) -> collections.abc.Iterator[int]: ...  # Y034 "__iter__" methods in classes like "BadIterator3" usually return "self" at runtime. Consider using "_typeshed.Self" in "BadIterator3.__iter__", e.g. "def __iter__(self: Self) -> Self: ..."
 
 class BadAsyncIterator(collections.abc.AsyncIterator[str]):
-    def __aiter__(self) -> typing.AsyncIterator[str]: ...  # Y034 "__aiter__" methods in classes like "BadAsyncIterator" usually return "self" at runtime. Consider using "_typeshed.Self" in "BadAsyncIterator.__aiter__", e.g. "def __aiter__(self: Self) -> Self: ..."
+    def __aiter__(self) -> typing.AsyncIterator[str]: ...  # Y034 "__aiter__" methods in classes like "BadAsyncIterator" usually return "self" at runtime. Consider using "_typeshed.Self" in "BadAsyncIterator.__aiter__", e.g. "def __aiter__(self: Self) -> Self: ..."  # Y027 Use "collections.abc.AsyncIterator[T]" instead of "typing.AsyncIterator[T]" (PEP 585 syntax)
 
 class Abstract(Iterator[str]):
     @abstractmethod

--- a/tests/exit_methods.pyi
+++ b/tests/exit_methods.pyi
@@ -1,9 +1,9 @@
 import types
 import typing
+from collections.abc import Awaitable
 from types import TracebackType
 from typing import (  # Y022 Use "type[MyClass]" instead of "typing.Type[MyClass]" (PEP 585 syntax)
     Any,
-    Awaitable,
     Type,
 )
 

--- a/tests/imports.pyi
+++ b/tests/imports.pyi
@@ -86,7 +86,7 @@ from typing_extensions import AsyncContextManager  # Y022 Use "contextlib.Abstra
 # BAD IMPORTS (Y023 code)
 from typing_extensions import ClassVar  # Y023 Use "typing.ClassVar[T]" instead of "typing_extensions.ClassVar[T]"
 from typing_extensions import Awaitable  # Y023 Use "collections.abc.Awaitable[T]" (or "typing.Awaitable[T]" in Python 2-compatible code) instead of "typing_extensions.Awaitable[T]"
-from typing_extensions import ContextManager  # Y023 Use "contextlib.AbstractContextManager[T]" (or "typing.ContextManager[T]" in Python 2-compatible code) instead of "typing_extensions.ContextManager[T]" (PEP 585 syntax)
+from typing_extensions import ContextManager  # Y023 Use "contextlib.AbstractContextManager[T]" (or "typing.ContextManager[T]" in Python 2-compatible code) instead of "typing_extensions.ContextManager[T]"
 from typing_extensions import runtime_checkable  # Y023 Use "typing.runtime_checkable" instead of "typing_extensions.runtime_checkable"
 from typing_extensions import AsyncGenerator  # Y023 Use "collections.abc.AsyncGenerator[YieldType, SendType]" (or "typing.AsyncGenerator[YieldType, SendType]" in Python 2-compatible code) instead of "typing_extensions.AsyncGenerator[YieldType, SendType]"
 from typing_extensions import Coroutine  # Y023 Use "collections.abc.Coroutine[YieldType, SendType, ReturnType]" (or "typing.Coroutine[YieldType, SendType, ReturnType]" in Python 2-compatible code) instead of "typing_extensions.Coroutine[YieldType, SendType, ReturnType]"
@@ -152,7 +152,7 @@ class Foo:
     attribute: typing_extensions.ClassVar[int]  # Y023 Use "typing.ClassVar[T]" instead of "typing_extensions.ClassVar[T]"
 
 h: typing_extensions.Awaitable[float]  # Y023 Use "collections.abc.Awaitable[T]" (or "typing.Awaitable[T]" in Python 2-compatible code) instead of "typing_extensions.Awaitable[T]"
-i: typing_extensions.ContextManager[None]  # Y023 Use "contextlib.AbstractContextManager[T]" (or "typing.ContextManager[T]" in Python 2-compatible code) instead of "typing_extensions.ContextManager[T]" (PEP 585 syntax)
+i: typing_extensions.ContextManager[None]  # Y023 Use "contextlib.AbstractContextManager[T]" (or "typing.ContextManager[T]" in Python 2-compatible code) instead of "typing_extensions.ContextManager[T]"
 
 # BAD ATTRIBUTE ACCESS (Y027 code)
 k: typing_extensions.OrderedDict[int, str]  # Y027 Use "collections.OrderedDict[KeyType, ValueType]" instead of "typing_extensions.OrderedDict[KeyType, ValueType]" (PEP 585 syntax)

--- a/tests/imports.pyi
+++ b/tests/imports.pyi
@@ -1,5 +1,7 @@
-# flags: --extend-ignore=Y037
-# NOTE: F401 & F811 are ignored in this file in the .flake8 config file
+# flags: --extend-ignore=F401,F811
+#
+# Note: DO NOT RUN ISORT ON THIS FILE.
+# It's excluded in our pyproject.toml.
 
 # GOOD IMPORTS
 import typing
@@ -33,40 +35,13 @@ from collections.abc import (
     MutableSequence,
     ByteString
 )
-
 # Things that are of no use for stub files are intentionally omitted.
 from typing import (
     Any,
-    Callable,
     ClassVar,
     Generic,
-    Optional,
     Protocol,
     TypeVar,
-    Union,
-    AbstractSet,
-    ByteString,
-    Container,
-    Hashable,
-    ItemsView,
-    Iterable,
-    Iterator,
-    KeysView,
-    Mapping,
-    MappingView,
-    MutableMapping,
-    MutableSequence,
-    MutableSet,
-    Sequence,
-    Sized,
-    ValuesView,
-    Awaitable,
-    AsyncIterator,
-    AsyncIterable,
-    Coroutine,
-    Collection,
-    AsyncGenerator,
-    Reversible,
     SupportsAbs,
     SupportsBytes,
     SupportsComplex,
@@ -74,7 +49,6 @@ from typing import (
     SupportsIndex,
     SupportsInt,
     SupportsRound,
-    Generator,
     BinaryIO,
     IO,
     NamedTuple,
@@ -111,20 +85,45 @@ from typing_extensions import AsyncContextManager  # Y022 Use "contextlib.Abstra
 
 # BAD IMPORTS (Y023 code)
 from typing_extensions import ClassVar  # Y023 Use "typing.ClassVar[T]" instead of "typing_extensions.ClassVar[T]"
-from typing_extensions import Awaitable  # Y023 Use "typing.Awaitable[T]" instead of "typing_extensions.Awaitable[T]"
+from typing_extensions import Awaitable  # Y023 Use "collections.abc.Awaitable[T]" (or "typing.Awaitable[T]" in Python 2-compatible code) instead of "typing_extensions.Awaitable[T]"
 from typing_extensions import ContextManager  # Y023 Use "contextlib.AbstractContextManager[T]" (or "typing.ContextManager[T]" in Python 2-compatible code) instead of "typing_extensions.ContextManager[T]" (PEP 585 syntax)
 from typing_extensions import runtime_checkable  # Y023 Use "typing.runtime_checkable" instead of "typing_extensions.runtime_checkable"
-from typing_extensions import AsyncGenerator  # Y023 Use "typing.AsyncGenerator[YieldType, SendType]" instead of "typing_extensions.AsyncGenerator[YieldType, SendType]"
-from typing_extensions import Coroutine  # Y023 Use "typing.Coroutine[YieldType, SendType, ReturnType]" instead of "typing_extensions.Coroutine[YieldType, SendType, ReturnType]"
+from typing_extensions import AsyncGenerator  # Y023 Use "collections.abc.AsyncGenerator[YieldType, SendType]" (or "typing.AsyncGenerator[YieldType, SendType]" in Python 2-compatible code) instead of "typing_extensions.AsyncGenerator[YieldType, SendType]"
+from typing_extensions import Coroutine  # Y023 Use "collections.abc.Coroutine[YieldType, SendType, ReturnType]" (or "typing.Coroutine[YieldType, SendType, ReturnType]" in Python 2-compatible code) instead of "typing_extensions.Coroutine[YieldType, SendType, ReturnType]"
 
 # BAD IMPORTS (Y027 code)
 from typing import ContextManager  # Y027 Use "contextlib.AbstractContextManager[T]" instead of "typing.ContextManager[T]" (PEP 585 syntax)
 from typing import OrderedDict  # Y027 Use "collections.OrderedDict[KeyType, ValueType]" instead of "typing.OrderedDict[KeyType, ValueType]" (PEP 585 syntax)
 from typing_extensions import OrderedDict  # Y027 Use "collections.OrderedDict[KeyType, ValueType]" instead of "typing_extensions.OrderedDict[KeyType, ValueType]" (PEP 585 syntax)
+from typing import Callable  # Y027 Use "collections.abc.Callable" instead of "typing.Callable" (PEP 585 syntax)
+from typing import ByteString  # Y027 Use "collections.abc.ByteString" instead of "typing.ByteString" (PEP 585 syntax)
+from typing import Container  # Y027 Use "collections.abc.Container[T]" instead of "typing.Container[T]" (PEP 585 syntax)
+from typing import Hashable  # Y027 Use "collections.abc.Hashable" instead of "typing.Hashable" (PEP 585 syntax)
+from typing import ItemsView  # Y027 Use "collections.abc.ItemsView[KeyType, ValueType]" instead of "typing.ItemsView[KeyType, ValueType]" (PEP 585 syntax)
+from typing import Iterable  # Y027 Use "collections.abc.Iterable[T]" instead of "typing.Iterable[T]" (PEP 585 syntax)
+from typing import Iterator  # Y027 Use "collections.abc.Iterator[T]" instead of "typing.Iterator[T]" (PEP 585 syntax)
+from typing import KeysView  # Y027 Use "collections.abc.KeysView[KeyType]" instead of "typing.KeysView[KeyType]" (PEP 585 syntax)
+from typing import Mapping  # Y027 Use "collections.abc.Mapping[KeyType, ValueType]" instead of "typing.Mapping[KeyType, ValueType]" (PEP 585 syntax)
+from typing import MappingView  # Y027 Use "collections.abc.MappingView" instead of "typing.MappingView" (PEP 585 syntax)
+from typing import MutableMapping  # Y027 Use "collections.abc.MutableMapping[KeyType, ValueType]" instead of "typing.MutableMapping[KeyType, ValueType]" (PEP 585 syntax)
+from typing import MutableSequence  # Y027 Use "collections.abc.MutableSequence[T]" instead of "typing.MutableSequence[T]" (PEP 585 syntax)
+from typing import MutableSet  # Y027 Use "collections.abc.MutableSet[T]" instead of "typing.MutableSet[T]" (PEP 585 syntax)
+from typing import Sequence  # Y027 Use "collections.abc.Sequence[T]" instead of "typing.Sequence[T]" (PEP 585 syntax)
+from typing import Sized  # Y027 Use "collections.abc.Sized" instead of "typing.Sized" (PEP 585 syntax)
+from typing import ValuesView  # Y027 Use "collections.abc.ValuesView[ValueType]" instead of "typing.ValuesView[ValueType]" (PEP 585 syntax)
+from typing import Awaitable  # Y027 Use "collections.abc.Awaitable[T]" instead of "typing.Awaitable[T]" (PEP 585 syntax)
+from typing import AsyncIterator  # Y027 Use "collections.abc.AsyncIterator[T]" instead of "typing.AsyncIterator[T]" (PEP 585 syntax)
+from typing import AsyncIterable  # Y027 Use "collections.abc.AsyncIterable[T]" instead of "typing.AsyncIterable[T]" (PEP 585 syntax)
+from typing import Coroutine  # Y027 Use "collections.abc.Coroutine[YieldType, SendType, ReturnType]" instead of "typing.Coroutine[YieldType, SendType, ReturnType]" (PEP 585 syntax)
+from typing import Collection  # Y027 Use "collections.abc.Collection[T]" instead of "typing.Collection[T]" (PEP 585 syntax)
+from typing import AsyncGenerator  # Y027 Use "collections.abc.AsyncGenerator[YieldType, SendType]" instead of "typing.AsyncGenerator[YieldType, SendType]" (PEP 585 syntax)
+from typing import Reversible  # Y027 Use "collections.abc.Reversible[T]" instead of "typing.Reversible[T]" (PEP 585 syntax)
+from typing import Generator  # Y027 Use "collections.abc.Generator[YieldType, SendType, ReturnType]" instead of "typing.Generator[YieldType, SendType, ReturnType]" (PEP 585 syntax)
 
 # BAD IMPORTS: OTHER
 from collections import namedtuple  # Y024 Use "typing.NamedTuple" instead of "collections.namedtuple"
 from collections.abc import Set  # Y025 Use "from collections.abc import Set as AbstractSet" to avoid confusion with "builtins.set"
+from typing import AbstractSet  # Y038 Use "from collections.abc import Set as AbstractSet" instead of "from typing import AbstractSet" (PEP 585 syntax)
 
 # GOOD ATTRIBUTE ACCESS
 foo: typing.SupportsIndex
@@ -152,7 +151,7 @@ class Spam:
 class Foo:
     attribute: typing_extensions.ClassVar[int]  # Y023 Use "typing.ClassVar[T]" instead of "typing_extensions.ClassVar[T]"
 
-h: typing_extensions.Awaitable[float]  # Y023 Use "typing.Awaitable[T]" instead of "typing_extensions.Awaitable[T]"
+h: typing_extensions.Awaitable[float]  # Y023 Use "collections.abc.Awaitable[T]" (or "typing.Awaitable[T]" in Python 2-compatible code) instead of "typing_extensions.Awaitable[T]"
 i: typing_extensions.ContextManager[None]  # Y023 Use "contextlib.AbstractContextManager[T]" (or "typing.ContextManager[T]" in Python 2-compatible code) instead of "typing_extensions.ContextManager[T]" (PEP 585 syntax)
 
 # BAD ATTRIBUTE ACCESS (Y027 code)

--- a/tests/type_comments.pyi
+++ b/tests/type_comments.pyi
@@ -1,4 +1,5 @@
-from typing import Sequence, TypeAlias
+from collections.abc import Sequence
+from typing import TypeAlias
 
 a: TypeAlias = None  # type: int  # Y033 Do not use type comments in stubs (e.g. use "x: int" instead of "x = ... # type: int")
 b: TypeAlias = None  # type: str  # And here's an extra comment about why it's that type  # Y033 Do not use type comments in stubs (e.g. use "x: int" instead of "x = ... # type: int")


### PR DESCRIPTION
A regression test for https://github.com/python/typeshed/pull/7635

Refs #46 (but doesn't _quite_ close it).

---

**Changes made**
- Expand Y027 to cover all objects in `typing` that are aliases to objects in `collections.abc`, except for `AbstractSet`
- Add new Y038 error code to forbid import `AbstractSet` from `typing`
- Change the error message in Y023 to make it clear that imports from `collections.abc` are now preferred to imports from `typing`.
- Refactor Y023 logic in `pyi.py` so as to quell flake8 from complaining that `_check_import_or_attribute` was getting too complex.
- Some small refactorings of test files to make them compatible with the new checks.