### PR TITLE
Prepare for release 22.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## Unreleased
+## 22.5.0
 
 Features:
 * Introduce Y039: Use `str` instead of `typing.Text` for Python 3 stubs.

--- a/pyi.py
+++ b/pyi.py
@@ -38,7 +38,7 @@ else:
 if TYPE_CHECKING:
     from typing import Literal, TypeGuard
 
-__version__ = "22.4.1"
+__version__ = "22.5.0"
 
 LOG = logging.getLogger("flake8.pyi")
 


### PR DESCRIPTION
This release should allow us to delete some chunks from `check_new_syntax.py` over at typeshed.