### PR TITLE
CI: Add a `workflow_dispatch` trigger for the test suite

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
This allows us to manually trigger the test suite from the "Actions" tab, either from the repo itself or a fork.