### PR TITLE
Support Python 3.11

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -43,7 +43,8 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11-dev']
+      fail-fast: false
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Features:
   emits an error for assignments to `typing.Annotated`, `typing.Optional` and
   `typing.Any`, as well as subscripted `tuple`s, `dict`s, `set`s, `frozenset`s,
   `list`s, and `type`s.
+* Support Python 3.11.
 
 ## 22.5.1
 


### PR DESCRIPTION
No changes needed, but probably good to start running the CI on 3.11 anyway.

Also, set `fail-fast` to `false` for the pytest suite. It's annoying not to be able to see exactly which Python versions a PR is failing on; that can be useful information for working out what the incompatibility is.