### PR TITLE
Support `typing_extensions.overload` and `typing_extensions.NamedTuple`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Features:
   `typing.Any`, as well as subscripted `tuple`s, `dict`s, `set`s, `frozenset`s,
   `list`s, and `type`s.
 * Support Python 3.11.
+* Support `typing_extensions.overload` and `typing_extensions.NamedTuple`. (The latter
+  is not yet released, but will be in the next version of `typing_extensions`.)
 
 ## 22.5.1
 

--- a/pyi.py
+++ b/pyi.py
@@ -311,7 +311,6 @@ def _is_name(node: ast.expr | None, name: str) -> bool:
     return isinstance(node, ast.Name) and node.id == name
 
 
-_is_BaseException = partial(_is_name, name="BaseException")
 _TYPING_MODULES = frozenset({"typing", "typing_extensions"})
 
 
@@ -341,13 +340,14 @@ def _is_object(node: ast.expr | None, name: str, *, from_: Container[str]) -> bo
     )
 
 
+_is_BaseException = partial(_is_object, name="BaseException", from_={"builtins"})
 _is_TypeAlias = partial(_is_object, name="TypeAlias", from_=_TYPING_MODULES)
-_is_NamedTuple = partial(_is_object, name="NamedTuple", from_={"typing"})
+_is_NamedTuple = partial(_is_object, name="NamedTuple", from_=_TYPING_MODULES)
 _is_TypedDict = partial(_is_object, name="TypedDict", from_=_TYPING_MODULES)
 _is_Literal = partial(_is_object, name="Literal", from_=_TYPING_MODULES)
 _is_abstractmethod = partial(_is_object, name="abstractmethod", from_={"abc"})
 _is_Any = partial(_is_object, name="Any", from_={"typing"})
-_is_overload = partial(_is_object, name="overload", from_={"typing"})
+_is_overload = partial(_is_object, name="overload", from_=_TYPING_MODULES)
 _is_final = partial(_is_object, name="final", from_=_TYPING_MODULES)
 _is_Final = partial(_is_object, name="Final", from_=_TYPING_MODULES)
 _is_Self = partial(_is_object, name="Self", from_=({"_typeshed"} | _TYPING_MODULES))

--- a/tests/calls.pyi
+++ b/tests/calls.pyi
@@ -1,8 +1,11 @@
 import typing
 from typing import NamedTuple, TypedDict
 
+import typing_extensions
+
 T = NamedTuple("T", [('foo', int), ('bar', str)])  # Y028 Use class-based syntax for NamedTuples
 U = typing.NamedTuple("U", [('baz', bytes)])  # Y028 Use class-based syntax for NamedTuples
+S = typing_extensions.NamedTuple("S", [('baz', bytes)])  # Y028 Use class-based syntax for NamedTuples
 
 class V(NamedTuple):
     foo: int
@@ -11,7 +14,7 @@ class V(NamedTuple):
 # BAD TYPEDDICTS
 W = TypedDict("W", {'foo': str, 'bar': int})  # Y031 Use class-based syntax for TypedDicts where possible
 B = typing.TypedDict("B", {'foo': str, 'bar': int})  # Y031 Use class-based syntax for TypedDicts where possible
-WithTotal = TypedDict("WithTotal", {'foo': str, 'bar': int}, total=False)  # Y031 Use class-based syntax for TypedDicts where possible
+WithTotal = typing_extensions.TypedDict("WithTotal", {'foo': str, 'bar': int}, total=False)  # Y031 Use class-based syntax for TypedDicts where possible
 
 # we don't want these two to raise errors (type-checkers already do that for us),
 # we just want to make sure the plugin doesn't crash if it comes across an invalid TypedDict
@@ -19,8 +22,8 @@ InvalidTypedDict = TypedDict("InvalidTypedDict", {7: 9, b"wot": [8, 3]})
 WeirdThirdArg = TypedDict("WeirdThirdArg", {'foo': int, "wot": str}, "who knows?")
 
 # GOOD TYPEDDICTS
-C = TypedDict("B", {'field has a space': list[int]})
-D = TypedDict("C", {'while': bytes, 'for': int})
+C = typing.TypedDict("B", {'field has a space': list[int]})
+D = typing_extensions.TypedDict("C", {'while': bytes, 'for': int})
 E = TypedDict("D", {'[][]': dict[str, int]})
 F = TypedDict("E", {'1': list[str], '2': str})
 

--- a/tests/classdefs.pyi
+++ b/tests/classdefs.pyi
@@ -1,3 +1,5 @@
+# flags: --extend-ignore=Y023
+
 import abc
 import builtins
 import collections.abc
@@ -6,6 +8,7 @@ from abc import abstractmethod
 from collections.abc import AsyncIterator, Iterator
 from typing import Any, overload
 
+import typing_extensions
 from _typeshed import Self
 from typing_extensions import final
 
@@ -34,7 +37,7 @@ class Good:
     def __ior__(self: Self, other: Self) -> Self: ...
 
 class Fine:
-    @overload
+    @typing_extensions.overload
     def __new__(cls, foo: int) -> FineSubclass: ...
     @overload
     def __new__(cls, *args: Any, **kwargs: Any) -> Fine: ...

--- a/tests/exit_methods.pyi
+++ b/tests/exit_methods.pyi
@@ -1,12 +1,11 @@
+# flags: --extend-ignore=Y022
+
 import builtins
 import types
 import typing
 from collections.abc import Awaitable
 from types import TracebackType
-from typing import (  # Y022 Use "type[MyClass]" instead of "typing.Type[MyClass]" (PEP 585 syntax)
-    Any,
-    Type,
-)
+from typing import Any, Type
 
 import typing_extensions
 
@@ -16,12 +15,12 @@ class One:
     async def __aexit__(self, *args) -> str: ...
 
 class Two:
-    def __exit__(self, typ: type[BaseException] | None, *args: builtins.object) -> bool | None: ...
+    def __exit__(self, typ: type[builtins.BaseException] | None, *args: builtins.object) -> bool | None: ...
     async def __aexit__(self, typ: Type[BaseException] | None, *args: object) -> bool: ...
 
 class Three:
-    def __exit__(self, __typ: typing.Type[BaseException] | None, exc: BaseException | None, *args: object) -> None: ...  # Y022 Use "type[MyClass]" instead of "typing.Type[MyClass]" (PEP 585 syntax)
-    async def __aexit__(self, typ: typing_extensions.Type[BaseException] | None, __exc: BaseException | None, *args: object) -> None: ...  # Y022 Use "type[MyClass]" instead of "typing_extensions.Type[MyClass]" (PEP 585 syntax)
+    def __exit__(self, __typ: typing.Type[BaseException] | None, exc: BaseException | None, *args: object) -> None: ...
+    async def __aexit__(self, typ: typing_extensions.Type[BaseException] | None, __exc: BaseException | None, *args: object) -> None: ...
 
 class Four:
     def __exit__(self, typ: type[BaseException] | None, exc: BaseException | None, tb: TracebackType | None) -> None: ...


### PR DESCRIPTION
- Y028 currently isn't emitted if somebody uses assignment-based syntax for `typing_extensions.NamedTuple` in a stub. `typing_extensions.NamedTuple` doesn't exist yet, but it will exist in the next release of `typing_extensions`, and in the future we might want to use it in stubs for generic `NamedTuple`s.
- Y034 has some exemptions for methods decorated with `@typing.overload`. Make sure those exemptions also work for `typing_extensions.overload`.
- Make it legal to annotate the first argument in an `__(a)exit__` method with `builtins.BaseException` (as opposed to just `BaseException`).