### PR TITLE
Introduce Y042: Use `__hash__: ClassVar[None]` instead of `__hash__: None`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Features:
 * Introduce Y041: Ban redundant numeric unions (`int | float`, `int | complex`,
   `float | complex`).
+* Introduce Y042: Use `__hash__: ClassVar[None]` instead of `__hash__: None`.
 * Improve error message for Y026 check.
 * Expand Y026 check. Since version 22.4.0, this has only emitted an error for
   assignments to `typing.Literal`, `typing.Union`, and PEP 604 unions. It now also

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ currently emitted:
 | Y039 | Use `str` instead of `typing.Text`. This error code is incompatible with stubs supporting Python 2.
 | Y040 | Never explicitly inherit from `object`, as all classes implicitly inherit from `object` in Python 3. This error code is incompatible with stubs supporting Python 2.
 | Y041 | Y041 detects redundant numeric unions. For example, PEP 484 specifies that type checkers should treat `int` as an implicit subtype of `float`, so `int` is redundant in the union `int \| float`. In the same way, `int` is redundant in the union `int \| complex`, and `float` is redundant in the union `float \| complex`.
+| Y042 | Use `__hash__: ClassVar[None]` instead of `__hash__: None`.
 
 Many error codes enforce modern conventions, and some cannot yet be used in
 all cases:

--- a/pyi.py
+++ b/pyi.py
@@ -917,7 +917,7 @@ class PyiVisitor(ast.NodeVisitor):
         else:
             self.generic_visit(node)
 
-    # Y043: Error for alias names in "T"
+    # Y043: Error for alias names ending in "T"
     # (plus possibly a single digit afterwards), but only if:
     #
     # - The name starts with "_"

--- a/tests/attribute_annotations.pyi
+++ b/tests/attribute_annotations.pyi
@@ -1,6 +1,6 @@
 import sys
 import typing
-from typing import Final, TypeAlias
+from typing import Any, ClassVar, Final, TypeAlias
 
 import typing_extensions
 
@@ -25,6 +25,7 @@ field14: Final = True
 field15: Final = ('a', 'b', 'c')
 field16: typing.Final = "foo"
 field17: typing_extensions.Final = "foo"
+__hash__: None
 
 class Foo:
     field1: int
@@ -51,3 +52,10 @@ class Foo:
         field18 = "z"  # Y015 Bad default value. Use "field18 = ..." instead of "field18 = 'z'"  # Y020 Quoted annotations should never be used in stubs
     else:
         field19 = "w"  # Y015 Bad default value. Use "field19 = ..." instead of "field19 = 'w'"  # Y020 Quoted annotations should never be used in stubs
+    __hash__: None  # Y042 Use "__hash__: ClassVar[None]" instead of "__hash__: None"
+
+class Bar:
+    __hash__: ClassVar[None]
+
+class Baz:
+    __hash__: Any


### PR DESCRIPTION
Resolves #189.

This check is a regression test for https://github.com/python/typeshed/pull/7485.