### PR TITLE
Introduce Y043: Ban type alias names from ending in 'T'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Features:
   emits an error for assignments to `typing.Annotated`, `typing.Optional` and
   `typing.Any`, as well as subscripted `tuple`s, `dict`s, `set`s, `frozenset`s,
   `list`s, and `type`s.
+* Introduce Y043: Ban type aliases from having names ending with an uppercase "T".
 * Support Python 3.11.
 * Support `typing_extensions.overload` and `typing_extensions.NamedTuple`. (The latter
   is not yet released, but will be in the next version of `typing_extensions`.)

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ currently emitted:
 | Y039 | Use `str` instead of `typing.Text`. This error code is incompatible with stubs supporting Python 2.
 | Y040 | Never explicitly inherit from `object`, as all classes implicitly inherit from `object` in Python 3. This error code is incompatible with stubs supporting Python 2.
 | Y041 | Y041 detects redundant numeric unions. For example, PEP 484 specifies that type checkers should treat `int` as an implicit subtype of `float`, so `int` is redundant in the union `int \| float`. In the same way, `int` is redundant in the union `int \| complex`, and `float` is redundant in the union `float \| complex`.
+| Y043 | Do not use names ending in "T" for private type aliases. (The "T" suffix implies that an object is a `TypeVar`.)
 
 Many error codes enforce modern conventions, and some cannot yet be used in
 all cases:

--- a/tests/aliases.pyi
+++ b/tests/aliases.pyi
@@ -58,3 +58,12 @@ class Foo:
 
 f: Foo = ...
 baz = f.baz
+
+_PrivateAliasT: TypeAlias = str | int  # Y043 Bad name for a type alias (the "T" suffix implies a TypeVar)
+_PrivateAliasT2: TypeAlias = typing.Any  # Y043 Bad name for a type alias (the "T" suffix implies a TypeVar)
+_PrivateAliasT3: TypeAlias = Literal["not", "a", "chance"]  # Y043 Bad name for a type alias (the "T" suffix implies a TypeVar)
+PublicAliasT: TypeAlias = str | int
+PublicAliasT2: TypeAlias = Union[str, bytes]
+_ABCDEFGHIJKLMNOPQRST: TypeAlias = typing.Any
+_PrivateAliasS: TypeAlias = Literal["I", "guess", "this", "is", "okay"]
+_PrivateAliasS2: TypeAlias = Annotated[str, "also okay"]


### PR DESCRIPTION
Fixes #234