### PR TITLE
type_comments.pyi: fix nit

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -15,11 +15,6 @@
 #       E305 expected 2 blank lines
 #       E701 multiple statements on one line (colon) -- disallows "..." on the same line
 #       E704 multiple statements on one line (def) -- disallows function body on the same line as the def
-#
-# tests/type_comments.pyi adds the following ignore codes for that specific file:
-#       F723 syntax error in type comment
-#       E261 at least two spaces before inline comment
-#       E262 inline comment should start with '# '
 
 [flake8]
 max-line-length = 80
@@ -28,4 +23,3 @@ select = B,C,E,F,W,Y,B9
 per-file-ignores =
   *.py: E203, E501, W503, W291, W293
   *.pyi: E301, E302, E305, E501, E701, E704, W503
-  tests/type_comments.pyi: E261, E262, E301, E302, E305, E501, E701, E704, F723, W503

--- a/tests/type_comments.pyi
+++ b/tests/type_comments.pyi
@@ -1,3 +1,9 @@
+# flags: --extend-ignore=F723,E261,E262
+#
+# F723: syntax error in type comment
+# E261: at least two spaces before inline comment
+# E262: inline comment should start with '# '
+
 from collections.abc import Sequence
 from typing import TypeAlias
 


### PR DESCRIPTION
Use a flag at the top of the test file, rather than special-casing it in `.flake8`, like we do with all the other test files