### PR TITLE
Introduce Y042: type alias names should use CamelCase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Features:
   emits an error for assignments to `typing.Annotated`, `typing.Optional` and
   `typing.Any`, as well as subscripted `tuple`s, `dict`s, `set`s, `frozenset`s,
   `list`s, and `type`s.
+* Introduce Y042: Type alias names should use CamelCase rather than snake_case
 * Introduce Y043: Ban type aliases from having names ending with an uppercase "T".
 * Support Python 3.11.
 * Support `typing_extensions.overload` and `typing_extensions.NamedTuple`. (The latter

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ currently emitted:
 | Y039 | Use `str` instead of `typing.Text`. This error code is incompatible with stubs supporting Python 2.
 | Y040 | Never explicitly inherit from `object`, as all classes implicitly inherit from `object` in Python 3. This error code is incompatible with stubs supporting Python 2.
 | Y041 | Y041 detects redundant numeric unions. For example, PEP 484 specifies that type checkers should treat `int` as an implicit subtype of `float`, so `int` is redundant in the union `int \| float`. In the same way, `int` is redundant in the union `int \| complex`, and `float` is redundant in the union `float \| complex`.
+| Y042 | Type alias names should use CamelCase rather than snake_case
 | Y043 | Do not use names ending in "T" for private type aliases. (The "T" suffix implies that an object is a `TypeVar`.)
 | Y044 | `from __future__ import annotations` has no effect in stub files, as forward references in stubs are enabled by default.
 

--- a/pyi.py
+++ b/pyi.py
@@ -929,10 +929,15 @@ class PyiVisitor(ast.NodeVisitor):
         if _is_TypeAlias(node_annotation):
             with self.visiting_TypeAlias.enabled():
                 self.generic_visit(node)
-            if isinstance(node_target, ast.Name) and self._Y043_REGEX.match(
-                target_name
-            ):
-                self.error(node, Y043)
+            if isinstance(node_target, ast.Name):
+                if target_name.startswith("_"):
+                    if target_name[1].islower():
+                        self.error(node, Y042)
+                else:
+                    if target_name[0].islower():
+                        self.error(node, Y042)
+                if self._Y043_REGEX.match(target_name):
+                    self.error(node, Y043)
             return
 
         self.generic_visit(node)
@@ -1672,5 +1677,6 @@ Y038 = 'Y038 Use "from collections.abc import Set as AbstractSet" instead of "fr
 Y039 = 'Y039 Use "str" instead of "typing.Text"'
 Y040 = 'Y040 Do not inherit from "object" explicitly, as it is redundant in Python 3'
 Y041 = 'Y041 Use "{implicit_supertype}" instead of "{implicit_subtype} | {implicit_supertype}" (see "The numeric tower" in PEP 484)'
+Y042 = "Y042 Type aliases should use the CamelCase naming convention"
 Y043 = 'Y043 Bad name for a type alias (the "T" suffix implies a TypeVar)'
 Y044 = 'Y044 "from __future__ import annotations" has no effect in stub files.'

--- a/pyi.py
+++ b/pyi.py
@@ -900,6 +900,8 @@ class PyiVisitor(ast.NodeVisitor):
         else:
             self.generic_visit(node)
 
+    _Y042_REGEX = re.compile(r"^_?[a-z]")
+
     # Y043: Error for alias names in "T"
     # (plus possibly a single digit afterwards), but only if:
     #
@@ -930,12 +932,8 @@ class PyiVisitor(ast.NodeVisitor):
             with self.visiting_TypeAlias.enabled():
                 self.generic_visit(node)
             if isinstance(node_target, ast.Name):
-                if target_name.startswith("_"):
-                    if target_name[1].islower():
-                        self.error(node, Y042)
-                else:
-                    if target_name[0].islower():
-                        self.error(node, Y042)
+                if self._Y042_REGEX.match(target_name):
+                    self.error(node, Y042)
                 if self._Y043_REGEX.match(target_name):
                     self.error(node, Y043)
             return

--- a/tests/aliases.pyi
+++ b/tests/aliases.pyi
@@ -83,3 +83,6 @@ _PrivateAliasS2: TypeAlias = Annotated[str, "also okay"]
 
 snake_case_alias1: TypeAlias = str | int  # Y042 Type aliases should use the CamelCase naming convention
 _snake_case_alias2: TypeAlias = Literal["whatever"]  # Y042 Type aliases should use the CamelCase naming convention
+
+# check that this edge case doesn't crash the plugin
+_: TypeAlias = str | int

--- a/tests/aliases.pyi
+++ b/tests/aliases.pyi
@@ -80,3 +80,6 @@ PublicAliasT2: TypeAlias = Union[str, bytes]
 _ABCDEFGHIJKLMNOPQRST: TypeAlias = typing.Any
 _PrivateAliasS: TypeAlias = Literal["I", "guess", "this", "is", "okay"]
 _PrivateAliasS2: TypeAlias = Annotated[str, "also okay"]
+
+snake_case_alias1: TypeAlias = str | int  # Y042 Type aliases should use the CamelCase naming convention
+_snake_case_alias2: TypeAlias = Literal["whatever"]  # Y042 Type aliases should use the CamelCase naming convention

--- a/tests/attribute_annotations.pyi
+++ b/tests/attribute_annotations.pyi
@@ -15,7 +15,7 @@ field8 = False  # Y015 Bad default value. Use "field8 = ..." instead of "field8 
 
 # We don't want this one to trigger Y015 -- it's valid as a TypeAlias
 field9 = None  # Y026 Use typing_extensions.TypeAlias for type aliases, e.g. "field9: TypeAlias = None"
-field10: TypeAlias = None
+Field10: TypeAlias = None
 
 # Tests for Final
 field11: Final = 1

--- a/tests/type_comments.pyi
+++ b/tests/type_comments.pyi
@@ -7,12 +7,12 @@
 from collections.abc import Sequence
 from typing import TypeAlias
 
-a: TypeAlias = None  # type: int  # Y033 Do not use type comments in stubs (e.g. use "x: int" instead of "x = ... # type: int")
-b: TypeAlias = None  # type: str  # And here's an extra comment about why it's that type  # Y033 Do not use type comments in stubs (e.g. use "x: int" instead of "x = ... # type: int")
-c: TypeAlias = None  #type: int  # Y033 Do not use type comments in stubs (e.g. use "x: int" instead of "x = ... # type: int")
-d: TypeAlias = None  #      type: int  # Y033 Do not use type comments in stubs (e.g. use "x: int" instead of "x = ... # type: int")
-e: TypeAlias = None#    type: int  # Y033 Do not use type comments in stubs (e.g. use "x: int" instead of "x = ... # type: int")
-f: TypeAlias = None#type:int  # Y033 Do not use type comments in stubs (e.g. use "x: int" instead of "x = ... # type: int")
+A: TypeAlias = None  # type: int  # Y033 Do not use type comments in stubs (e.g. use "x: int" instead of "x = ... # type: int")
+B: TypeAlias = None  # type: str  # And here's an extra comment about why it's that type  # Y033 Do not use type comments in stubs (e.g. use "x: int" instead of "x = ... # type: int")
+C: TypeAlias = None  #type: int  # Y033 Do not use type comments in stubs (e.g. use "x: int" instead of "x = ... # type: int")
+D: TypeAlias = None  #      type: int  # Y033 Do not use type comments in stubs (e.g. use "x: int" instead of "x = ... # type: int")
+E: TypeAlias = None#    type: int  # Y033 Do not use type comments in stubs (e.g. use "x: int" instead of "x = ... # type: int")
+F: TypeAlias = None#type:int  # Y033 Do not use type comments in stubs (e.g. use "x: int" instead of "x = ... # type: int")
 
 def func(
     arg1,  # type: dict[str, int]  # Y033 Do not use type comments in stubs (e.g. use "x: int" instead of "x = ... # type: int")
@@ -20,18 +20,18 @@ def func(
 ): ...
 
 class Foo:
-    attr: TypeAlias = None  # type: set[str]  # Y033 Do not use type comments in stubs (e.g. use "x: int" instead of "x = ... # type: int")
+    Attr: TypeAlias = None  # type: set[str]  # Y033 Do not use type comments in stubs (e.g. use "x: int" instead of "x = ... # type: int")
 
-g: TypeAlias = None  # type: ignore
-h: TypeAlias = None  # type: ignore[attr-defined]
-i: TypeAlias = None  #type: ignore
-j: TypeAlias = None  #      type: ignore
-k: TypeAlias = None#    type: ignore
-l: TypeAlias = None#type:ignore
+G: TypeAlias = None  # type: ignore
+H: TypeAlias = None  # type: ignore[attr-defined]
+I: TypeAlias = None  #type: ignore
+J: TypeAlias = None  #      type: ignore
+K: TypeAlias = None#    type: ignore
+L: TypeAlias = None#type:ignore
 
 # Whole line commented out  # type: int
-m: TypeAlias = None  # type: can't parse me!
+M: TypeAlias = None  # type: can't parse me!
 
 class Bar:
-    n: TypeAlias = None  # type: can't parse me either!
+    N: TypeAlias = None  # type: can't parse me either!
     # This whole line is commented out and indented # type: str

--- a/tests/union_duplicates.pyi
+++ b/tests/union_duplicates.pyi
@@ -21,9 +21,9 @@ def f5_union(x: typing.Union[int, int, None]) -> None: ...  # Y016 Duplicate uni
 
 just_literals_subscript_union: Union[Literal[1], typing.Literal[2]]  # Y030 Multiple Literal members in a union. Use a single Literal, e.g. "Literal[1, 2]".
 mixed_subscript_union: Union[str, Literal['foo'], typing_extensions.Literal['bar']]  # Y030 Multiple Literal members in a union. Combine them into one, e.g. "Literal['foo', 'bar']".
-just_literals_pipe_union: TypeAlias = Literal[True] | Literal['idk']  # Y030 Multiple Literal members in a union. Use a single Literal, e.g. "Literal[True, 'idk']".
-mixed_pipe_union: TypeAlias = Union[Literal[966], int, Literal['baz']]  # Y030 Multiple Literal members in a union. Combine them into one, e.g. "Literal[966, 'baz']".
-many_literal_members_but_needs_combining: TypeAlias = int | Literal['a', 'b'] | Literal['baz']  # Y030 Multiple Literal members in a union. Combine them into one, e.g. "Literal['a', 'b', 'baz']".
+just_literals_pipe_union: TypeAlias = Literal[True] | Literal['idk']  # Y042 Type aliases should use the CamelCase naming convention  # Y030 Multiple Literal members in a union. Use a single Literal, e.g. "Literal[True, 'idk']".
+_mixed_pipe_union: TypeAlias = Union[Literal[966], int, Literal['baz']]  # Y042 Type aliases should use the CamelCase naming convention  # Y030 Multiple Literal members in a union. Combine them into one, e.g. "Literal[966, 'baz']".
+ManyLiteralMembersButNeedsCombining: TypeAlias = int | Literal['a', 'b'] | Literal['baz']  # Y030 Multiple Literal members in a union. Combine them into one, e.g. "Literal['a', 'b', 'baz']".
 
 a: int | float  # Y041 Use "float" instead of "int | float" (see "The numeric tower" in PEP 484)
 b: Union[builtins.float, str, bytes, builtins.int]  # Y041 Use "float" instead of "int | float" (see "The numeric tower" in PEP 484)


### PR DESCRIPTION
Closes #238. The quest for a viable Y042 candidate continues!