### PR TITLE
Introduce Y045: Ban returning `(Async)Iterable` from `__(a)iter__` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ Features:
   is not yet released, but will be in the next version of `typing_extensions`.)
 * Introduce Y044: Discourage unnecessary `from __future__ import annotations` import.
   Contributed by Torsten Wörtwein.
+* Introduce Y045: Ban returning `(Async)Iterable` from `__(a)iter__` methods.
+* Slightly expand Y034 to cover the case where a class inheriting from `(Async)Iterator`
+  returns `(Async)Iterable` from `__(a)iter__`. These classes should nearly always return
+  `Self` from these methods.
 
 ## 22.5.1
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ currently emitted:
 | Y041 | Y041 detects redundant numeric unions. For example, PEP 484 specifies that type checkers should treat `int` as an implicit subtype of `float`, so `int` is redundant in the union `int \| float`. In the same way, `int` is redundant in the union `int \| complex`, and `float` is redundant in the union `float \| complex`.
 | Y043 | Do not use names ending in "T" for private type aliases. (The "T" suffix implies that an object is a `TypeVar`.)
 | Y044 | `from __future__ import annotations` has no effect in stub files, as forward references in stubs are enabled by default.
+| Y045 | `__iter__` methods should never return `Iterable[T]`, as they should always return some kind of iterator.
 
 Many error codes enforce modern conventions, and some cannot yet be used in
 all cases:

--- a/tests/classdefs.pyi
+++ b/tests/classdefs.pyi
@@ -5,7 +5,7 @@ import builtins
 import collections.abc
 import typing
 from abc import abstractmethod
-from collections.abc import AsyncIterator, Iterator
+from collections.abc import AsyncIterable, AsyncIterator, Iterable, Iterator
 from typing import Any, overload
 
 import typing_extensions
@@ -87,8 +87,18 @@ class BadIterator2(typing.Iterator[int]):  # Y027 Use "collections.abc.Iterator[
 class BadIterator3(typing.Iterator[int]):  # Y027 Use "collections.abc.Iterator[T]" instead of "typing.Iterator[T]" (PEP 585 syntax)
     def __iter__(self) -> collections.abc.Iterator[int]: ...  # Y034 "__iter__" methods in classes like "BadIterator3" usually return "self" at runtime. Consider using "_typeshed.Self" in "BadIterator3.__iter__", e.g. "def __iter__(self: Self) -> Self: ..."
 
+class BadIterator4(Iterator[int]):
+    # Note: *Iterable*, not *Iterator*, returned!
+    def __iter__(self) -> Iterable[int]: ...  # Y034 "__iter__" methods in classes like "BadIterator4" usually return "self" at runtime. Consider using "_typeshed.Self" in "BadIterator4.__iter__", e.g. "def __iter__(self: Self) -> Self: ..."
+
+class IteratorReturningIterable:
+    def __iter__(self) -> Iterable[str]: ...  # Y045 "__iter__" methods should return an Iterator, not an Iterable
+
 class BadAsyncIterator(collections.abc.AsyncIterator[str]):
     def __aiter__(self) -> typing.AsyncIterator[str]: ...  # Y034 "__aiter__" methods in classes like "BadAsyncIterator" usually return "self" at runtime. Consider using "_typeshed.Self" in "BadAsyncIterator.__aiter__", e.g. "def __aiter__(self: Self) -> Self: ..."  # Y027 Use "collections.abc.AsyncIterator[T]" instead of "typing.AsyncIterator[T]" (PEP 585 syntax)
+
+class AsyncIteratorReturningAsyncIterable:
+    def __aiter__(self) -> AsyncIterable[str]: ...  # Y045 "__aiter__" methods should return an AsyncIterator, not an AsyncIterable
 
 class Abstract(Iterator[str]):
     @abstractmethod


### PR DESCRIPTION
Fixes #247