### PR TITLE
Type check on 3.7; update various test dependencies

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,11 +15,15 @@ jobs:
     name: mypy
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    strategy:
+      matrix:
+        python-version: ['3.7', '3.10']
+      fail-fast: false
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: ${{ matrix.python-version }}
     - run: pip install -r requirements-dev.txt
     - run: mypy pyi.py
   flake8:

--- a/pyi.py
+++ b/pyi.py
@@ -40,7 +40,10 @@ else:
 
 
 if TYPE_CHECKING:
-    from typing import Literal, TypeGuard
+    # We don't have typing_extensions as a runtime dependency,
+    # but all our annotations are stringized due to __future__ annotations,
+    # and mypy thinks typing_extensions is part of the stdlib.
+    from typing_extensions import Literal, TypeGuard
 
 __version__ = "22.7.0"
 
@@ -1020,7 +1023,8 @@ class PyiVisitor(ast.NodeVisitor):
         if len(literals_in_union) < 2:
             return
 
-        new_literal_members: list[ast.expr] = []
+        # Contains ast.slice nodes on Python <3.9; contains ast.expr nodes on Python >= 3.9
+        new_literal_members: list[ast.expr | ast.slice] = []
 
         for literal in literals_in_union:
             if isinstance(literal, ast.Tuple):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 black==22.6.0
-pytest==6.2.5
-mypy==0.961
+pytest==7.1.2
+mypy==0.971
 isort==5.10.1
-flake8-bugbear==22.1.11
-types-pyflakes==2.4.0
+flake8-bugbear==22.7.1
+types-pyflakes==2.4.3
+ast_decompiler<1.0; python_version < '3.9'


### PR DESCRIPTION
- We don't currently pass a mypy type check on 3.7. Fix that, and run mypy on 3.7 in CI. This also necessitates adding `ast_decompiler` to `requirements-dev.txt` if you're running on Python <3.9.
- Update various test dependencies.