### PR TITLE
refactor: prefer contextlib.suppress to try/except pass

### DIFF
--- a/pyi.py
+++ b/pyi.py
@@ -9,7 +9,7 @@ import re
 import sys
 from collections import Counter
 from collections.abc import Container, Iterable, Iterator, Sequence
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from copy import deepcopy
 from dataclasses import dataclass
 from functools import partial
@@ -1672,7 +1672,8 @@ class PyiTreeChecker:
                     option.to_optparse().default = option.default
                     parser.parser.defaults[option.dest] = option.default
 
-        try:
+        with suppress(optparse.OptionConflictError):
+            # In tests, sometimes this option gets called twice for some reason.
             parser.add_option(
                 "--no-pyi-aware-file-checker",
                 default=False,
@@ -1680,9 +1681,6 @@ class PyiTreeChecker:
                 parse_from_config=True,
                 help="don't patch flake8 with .pyi-aware file checker",
             )
-        except optparse.OptionConflictError:
-            # In tests, sometimes this option gets called twice for some reason.
-            pass
 
     @classmethod
     def parse_options(


### PR DESCRIPTION
Use [contextlib](https://docs.python.org/3/library/contextlib.html)'s suppress method to silence a specific error, instead of passing in an exception handler.

The context manager slightly shortens the code and clarifies the intention to ignore the specific errors. The standard library feature was introduced following a [discussion](https://bugs.python.org/issue15806), where the consensus was that

> A key benefit here is in the priming effect for readers... The with statement form makes it clear before you start reading the code that certain exceptions won't propagate.