### PR TITLE
refactor: prefer yield from

### DIFF
--- a/pyi.py
+++ b/pyi.py
@@ -1655,8 +1655,8 @@ class PyiTreeChecker:
         path = Path(self.filename)
         if path.suffix == ".pyi":
             yield from _check_for_type_comments(path)
-            visitor = PyiVisitor(filename=path)
-            yield from visitor.run(LegacyNormalizer().visit(self.tree))
+            tree = LegacyNormalizer().visit(self.tree)
+            yield from PyiVisitor(filename=path).run(tree)
 
     @classmethod
     def add_options(cls, parser: OptionManager) -> None:

--- a/pyi.py
+++ b/pyi.py
@@ -1656,8 +1656,7 @@ class PyiTreeChecker:
         if path.suffix == ".pyi":
             yield from _check_for_type_comments(path)
             visitor = PyiVisitor(filename=path)
-            for error in visitor.run(LegacyNormalizer().visit(self.tree)):
-                yield error
+            yield from visitor.run(LegacyNormalizer().visit(self.tree))
 
     @classmethod
     def add_options(cls, parser: OptionManager) -> None:


### PR DESCRIPTION
Replaces yield as part a `for` loop with `yield from`

One little trick that often gets missed is that Python's `yield` keyword has a corresponding `yield from` for collections, so there's no need to iterate over a collection with a for loop. This makes the code slightly shorter and removes the mental overhead and extra variable used by the for loop. Eliminating the for loop also makes the `yield from` version about 15% faster.
