### PR TITLE
Shorten some line lengths, improve `.flake8` config file

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -3,7 +3,8 @@
 # The following rule now goes against PEP8:
 #       W503 line break before binary operator
 #
-# The following rules are incompatible with or enforced by black:
+# The following rules are incompatible with or largely enforced by black:
+#       B950 Line too long (flake8-bugbear equivalent of E501)
 #       E203 whitespace before ':' -- .py files only
 #       E501 line too long
 #       W291 trailing whitespace -- .py files only
@@ -21,6 +22,5 @@ max-line-length = 80
 max-complexity = 12
 select = B,C,E,F,W,Y,B9
 per-file-ignores =
-  # TODO: reenable some of the bugbear checks
   *.py: B950, E203, E501, W503, W291, W293
-  *.pyi: B902, B903, B950, E301, E302, E305, E501, E701, E704, W503
+  *.pyi: B, E301, E302, E305, E501, E701, E704, W503


### PR DESCRIPTION
flake8-bugbear started issuing a lot more complaints when we upgraded to use flake8 5; I'm not quite sure why.

I don't think it's useful to have flake8-bugbear run on our test suite, so this PR proposes using a blanket `B` per-file ignore for our `.pyi` files. For `pyi.py`, the main complaint was that lots of lines were >88 characters long, and black had declined to reformat them because they were long strings or long comments. I tried enabling this check for `pyi.py`, but ultimately, I think it would be too annoying to enable it: there are good reasons to go slightly over 88 characters in quite a few places. Having said that, bugbear also had a good point in several places where we didn't really _need_ to have line lengths so long, so I've tried to fix the easy cases in this PR.