### PR TITLE
Pin `gh-action-pypi-publish` to `release/v1`; bump `types-pyflakes` version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,6 +34,6 @@ jobs:
         .
     - name: Publish distribution to PyPI
       if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,5 +3,5 @@ pytest==7.1.2
 mypy==0.971
 isort==5.10.1
 flake8-bugbear==22.7.1
-types-pyflakes==2.4.3
+types-pyflakes==2.5.0
 ast_decompiler<1.0; python_version < '3.9'


### PR DESCRIPTION
Fixes #261