### PR TITLE
Introduce Y051: Detect redundant unions between `Literal` types and builtin supertypes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ New error codes:
 * Y049: Detect unused `TypedDict` definitions.
 * Y050: Prefer `typing_extensions.Never` for argument annotations over
   `typing.NoReturn`.
+* Y051: Detect redundant unions between `Literal` types and builtin supertypes
+  (e.g. `Literal["foo"] | str`, or `Literal[5] | int`).
 
 Other enhancements:
 * Support `mypy_extensions.TypedDict`.

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ currently emitted:
 | Y048 | Function bodies should contain exactly one statement. (Note that if a function body includes a docstring, the docstring counts as a "statement".)
 | Y049 | A private `TypedDict` should be used at least once in the file in which it is defined.
 | Y050 | Prefer `typing_extensions.Never` over `typing.NoReturn` for argument annotations. This is a purely stylistic choice in the name of readability.
+| Y051 | Y051 detect redundant unions between `Literal` types and builtin supertypes. For example, `Literal[5]` is redundant in the union `int | Literal[5]`, and `Literal[True]` is redundant in the union `Literal[True] | bool`.
 
 Many error codes enforce modern conventions, and some cannot yet be used in
 all cases:

--- a/pyi.py
+++ b/pyi.py
@@ -1109,13 +1109,13 @@ class PyiVisitor(ast.NodeVisitor):
             elif isinstance(literal, ast.NameConstant):
                 if type(literal.value) is bool:
                     literal_classes_present["bool"].append(literal)
-        for cls in literal_classes_present:
+        for cls, literals in literal_classes_present.items():
             if cls in analysis.builtins_classes_in_union:
-                literal_present = literal_classes_present[cls][0]
+                first_literal_present = literals[0]
                 self.error(
-                    literal_present,
+                    first_literal_present,
                     Y051.format(
-                        literal_subtype=f"Literal[{unparse(literal_present)}]",
+                        literal_subtype=f"Literal[{unparse(first_literal_present)}]",
                         builtin_supertype=cls,
                     ),
                 )

--- a/pyi.py
+++ b/pyi.py
@@ -1108,11 +1108,8 @@ class PyiVisitor(ast.NodeVisitor):
             elif isinstance(literal, ast.NameConstant):
                 if type(literal.value) is bool:
                     literal_classes_present["bool"].append(literal)
-        for cls in ("str", "bytes", "int", "bool"):
-            if (
-                cls in analysis.builtins_classes_in_union
-                and cls in literal_classes_present
-            ):
+        for cls in literal_classes_present:
+            if cls in analysis.builtins_classes_in_union:
                 literal_present = literal_classes_present[cls][0]
                 self.error(
                     literal_present,

--- a/pyi.py
+++ b/pyi.py
@@ -302,6 +302,7 @@ class LegacyNormalizer(ast.NodeTransformer):
             3.9 and newer:
                 Subscript(value=Name(id='Union'), slice=Tuple(...))
             """
+            self.generic_visit(node)
             return node.value
 
 

--- a/tests/union_duplicates.pyi
+++ b/tests/union_duplicates.pyi
@@ -20,9 +20,9 @@ def f4_union(x: typing.Union[int, None, int]) -> None: ...  # Y016 Duplicate uni
 def f5_union(x: typing.Union[int, int, None]) -> None: ...  # Y016 Duplicate union member "int"
 
 just_literals_subscript_union: Union[Literal[1], typing.Literal[2]]  # Y030 Multiple Literal members in a union. Use a single Literal, e.g. "Literal[1, 2]".
-mixed_subscript_union: Union[str, Literal['foo'], typing_extensions.Literal['bar']]  # Y030 Multiple Literal members in a union. Combine them into one, e.g. "Literal['foo', 'bar']".
+mixed_subscript_union: Union[bytes, Literal['foo'], typing_extensions.Literal['bar']]  # Y030 Multiple Literal members in a union. Combine them into one, e.g. "Literal['foo', 'bar']".
 just_literals_pipe_union: TypeAlias = Literal[True] | Literal['idk']  # Y042 Type aliases should use the CamelCase naming convention  # Y030 Multiple Literal members in a union. Use a single Literal, e.g. "Literal[True, 'idk']".
-_mixed_pipe_union: TypeAlias = Union[Literal[966], int, Literal['baz']]  # Y042 Type aliases should use the CamelCase naming convention  # Y047 Type alias "_mixed_pipe_union" is not used  # Y030 Multiple Literal members in a union. Combine them into one, e.g. "Literal[966, 'baz']".
+_mixed_pipe_union: TypeAlias = Union[Literal[966], bytes, Literal['baz']]  # Y042 Type aliases should use the CamelCase naming convention  # Y047 Type alias "_mixed_pipe_union" is not used  # Y030 Multiple Literal members in a union. Combine them into one, e.g. "Literal[966, 'baz']".
 ManyLiteralMembersButNeedsCombining: TypeAlias = int | Literal['a', 'b'] | Literal['baz']  # Y030 Multiple Literal members in a union. Combine them into one, e.g. "Literal['a', 'b', 'baz']".
 
 a: int | float  # Y041 Use "float" instead of "int | float" (see "The numeric tower" in PEP 484)
@@ -43,3 +43,14 @@ f: Literal["foo"] | Literal["bar"] | int | float | builtins.bool  # Y030 Multipl
 MyTypeAlias: TypeAlias = int | float | bool
 MySecondTypeAlias: TypeAlias = Union[builtins.int, str, complex, bool]
 MyThirdTypeAlias: TypeAlias = Mapping[str, int | builtins.float | builtins.bool]
+
+one: str | Literal["foo"]  # Y051 "Literal['foo']" is redundant in a union with "str"
+Two: TypeAlias = Union[Literal[b"bar", b"baz"], bytes]  # Y051 "Literal[b'bar']" is redundant in a union with "bytes"
+def three(arg: Literal[5] | builtins.int | Literal[9]) -> None: ...  # Y030 Multiple Literal members in a union. Combine them into one, e.g. "Literal[5, 9]".  # Y051 "Literal[5]" is redundant in a union with "int"
+
+class Four:
+    var: builtins.bool | Literal[True]  # Y051 "Literal[True]" is redundant in a union with "bool"
+
+DupesHereSoNoY051: TypeAlias = int | int | Literal[42]  # Y016 Duplicate union member "int"
+NightmareAlias1 = int | float | Literal[4] | Literal["foo"]  # Y026 Use typing_extensions.TypeAlias for type aliases, e.g. "NightmareAlias1: TypeAlias = int | float | Literal[4] | Literal['foo']"  # Y030 Multiple Literal members in a union. Combine them into one, e.g. "Literal[4, 'foo']".  # Y041 Use "float" instead of "int | float" (see "The numeric tower" in PEP 484)  # Y051 "Literal[4]" is redundant in a union with "int"
+nightmare_alias2: TypeAlias = int | float | Literal[4] | Literal["foo"]  # Y042 Type aliases should use the CamelCase naming convention  # Y030 Multiple Literal members in a union. Combine them into one, e.g. "Literal[4, 'foo']".  # Y051 "Literal[4]" is redundant in a union with "int"

--- a/tests/union_duplicates.pyi
+++ b/tests/union_duplicates.pyi
@@ -46,11 +46,11 @@ MyThirdTypeAlias: TypeAlias = Mapping[str, int | builtins.float | builtins.bool]
 
 one: str | Literal["foo"]  # Y051 "Literal['foo']" is redundant in a union with "str"
 Two: TypeAlias = Union[Literal[b"bar", b"baz"], bytes]  # Y051 "Literal[b'bar']" is redundant in a union with "bytes"
-def three(arg: Literal[5] | builtins.int | Literal[9]) -> None: ...  # Y030 Multiple Literal members in a union. Combine them into one, e.g. "Literal[5, 9]".  # Y051 "Literal[5]" is redundant in a union with "int"
+def three(arg: Literal["foo", 5] | builtins.int | Literal[9, "bar"]) -> None: ...  # Y030 Multiple Literal members in a union. Combine them into one, e.g. "Literal['foo', 5, 9, 'bar']".  # Y051 "Literal[5]" is redundant in a union with "int"
 
 class Four:
     var: builtins.bool | Literal[True]  # Y051 "Literal[True]" is redundant in a union with "bool"
 
 DupesHereSoNoY051: TypeAlias = int | int | Literal[42]  # Y016 Duplicate union member "int"
-NightmareAlias1 = int | float | Literal[4] | Literal["foo"]  # Y026 Use typing_extensions.TypeAlias for type aliases, e.g. "NightmareAlias1: TypeAlias = int | float | Literal[4] | Literal['foo']"  # Y030 Multiple Literal members in a union. Combine them into one, e.g. "Literal[4, 'foo']".  # Y041 Use "float" instead of "int | float" (see "The numeric tower" in PEP 484)  # Y051 "Literal[4]" is redundant in a union with "int"
-nightmare_alias2: TypeAlias = int | float | Literal[4] | Literal["foo"]  # Y042 Type aliases should use the CamelCase naming convention  # Y030 Multiple Literal members in a union. Combine them into one, e.g. "Literal[4, 'foo']".  # Y051 "Literal[4]" is redundant in a union with "int"
+NightmareAlias1 = int | float | Literal[4, b"bar"] | Literal["foo"]  # Y026 Use typing_extensions.TypeAlias for type aliases, e.g. "NightmareAlias1: TypeAlias = int | float | Literal[4, b'bar'] | Literal['foo']"  # Y030 Multiple Literal members in a union. Combine them into one, e.g. "Literal[4, b'bar', 'foo']".  # Y041 Use "float" instead of "int | float" (see "The numeric tower" in PEP 484)  # Y051 "Literal[4]" is redundant in a union with "int"
+nightmare_alias2: TypeAlias = int | float | Literal[True, 4] | Literal["foo"]  # Y042 Type aliases should use the CamelCase naming convention  # Y030 Multiple Literal members in a union. Combine them into one, e.g. "Literal[True, 4, 'foo']".  # Y051 "Literal[4]" is redundant in a union with "int"


### PR DESCRIPTION
Fixes #275. Cc. @twoertwein.