### PR TITLE
`README`: fix markup errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ currently emitted:
 | Y048 | Function bodies should contain exactly one statement. (Note that if a function body includes a docstring, the docstring counts as a "statement".)
 | Y049 | A private `TypedDict` should be used at least once in the file in which it is defined.
 | Y050 | Prefer `typing_extensions.Never` over `typing.NoReturn` for argument annotations. This is a purely stylistic choice in the name of readability.
-| Y051 | Y051 detect redundant unions between `Literal` types and builtin supertypes. For example, `Literal[5]` is redundant in the union `int | Literal[5]`, and `Literal[True]` is redundant in the union `Literal[True] | bool`.
+| Y051 | Y051 detect redundant unions between `Literal` types and builtin supertypes. For example, `Literal[5]` is redundant in the union `int \| Literal[5]`, and `Literal[True]` is redundant in the union `Literal[True] \| bool`.
 
 Many error codes enforce modern conventions, and some cannot yet be used in
 all cases:


### PR DESCRIPTION
Accidentally introduced in #279