### PR TITLE
Improve CI

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -20,7 +20,8 @@
 [flake8]
 max-line-length = 80
 max-complexity = 12
-select = B,C,E,F,W,Y,B9
+noqa-require-code = true
+select = B,C,E,F,W,Y,B9,NQA
 per-file-ignores =
   *.py: B950, E203, E501, W503, W291, W293
   *.pyi: B, E301, E302, E305, E501, E701, E704, W503

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.6.0  # must match requirements-dev.txt
+    rev: 22.8.0  # must match requirements-dev.txt
     hooks:
       - id: black
         language_version: python3.9

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,12 +4,16 @@ combine_as_imports = true
 skip = ["tests/imports.pyi"]
 
 [tool.black]
+target-version = ['py37']
+skip-magic-trailing-comma = true
 force-exclude = ".*\\.pyi"
 
 [tool.mypy]
 show_error_codes = true
+show_traceback = true
+pretty = true
 strict = true
-enable_error_code = "ignore-without-code"
+enable_error_code = "ignore-without-code,redundant-expr"
 warn_unreachable = true
 allow_subclassing_any = true
 allow_untyped_defs = true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,8 @@
-black==22.6.0
-pytest==7.1.2
+black==22.8.0      # Must match .pre-commit-config.yaml
+pytest==7.1.3
 mypy==0.971
-isort==5.10.1
-flake8-bugbear==22.7.1
+isort==5.10.1      # Must match .pre-commit-config.yaml
+flake8-bugbear==22.8.23
+flake8-noqa==1.2.9
 types-pyflakes==2.5.0
 ast_decompiler<1.0; python_version < '3.9'


### PR DESCRIPTION
- Add `flake8-noqa` as a plugin; enable the `noqa-require-code` option.
- Add some more config options for mypy and black.
- Bump the pinned versions of black and pytest.