### PR TITLE
No longer emit a `FutureWarning` when run with flake8<5; add a CI job to run with flake8<5

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -57,6 +57,21 @@ jobs:
     - run: pip install -e .
     - run: pip install -r requirements-dev.txt
     - run: python3 -m pytest -vv
+  tests-flake8-v4:
+    name: pytest suite with flake8 v4
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        # Run on Python 3.7, as the importlib_metadata compatibility problems with flake8 v5
+        # are much less on Python 3.8+, where importlib.metadata is available in the stdlib
+        python-version: 3.7
+    - run: pip install "flake8<5"
+    - run: pip install -e .
+    - run: pip install -r requirements-dev.txt
+    - run: python3 -m pytest -vv
   check-typeshed:
     name: typeshed_primer
     timeout-minutes: 5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ Bugfixes:
   `__all__` definitions.
 * Expand Y015 so that errors are emitted for assignments to negative numbers.
 
+Other changes:
+* Since v22.8.1, flake8-pyi has emitted a `FutureWarning` if run with flake8<5,
+  warning that the plugin would soon become incompatible with flake8<5. Due to
+  some issues that mean that some users are unable to upgrade to flake8>=5,
+  however, flake8-pyi no longer intends to remove support for running the
+  plugin with flake8<5 before Python 3.7 has reached end-of-life. As such, the
+  `FutureWarning` is no longer emitted.
+
 ## 22.8.2
 
 New error codes:

--- a/pyi.py
+++ b/pyi.py
@@ -44,19 +44,6 @@ __version__ = "22.8.2"
 LOG = logging.getLogger("flake8.pyi")
 FLAKE8_MAJOR_VERSION = flake8.__version_info__[0]
 
-if FLAKE8_MAJOR_VERSION < 5:
-    import warnings
-
-    warnings.warn(
-        (
-            "flake8-pyi will drop support for running with flake8 < 5.0.0 "
-            "in a future version. This will not happen until November 2022 "
-            "at the earliest."
-        ),
-        category=FutureWarning,
-    )
-
-
 if sys.version_info >= (3, 9):
     _LiteralMember: TypeAlias = ast.expr
 else:


### PR DESCRIPTION
See discussion in:

- https://github.com/PyCQA/flake8-pyi/pull/259#issuecomment-1268595970 (and following comments)
- https://github.com/python/importlib_metadata/issues/409