### PR TITLE
Specify encoding in open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 Bugfixes:
 * Specify encoding when opening files. Prevents `UnicodeDecodeError` on Windows
-  when the file contains non-CP1252 characters. (by @Avasam)
+  when the file contains non-CP1252 characters.
+  Contributed by [Avasam](https://github.com/Avasam).
 
 ## 22.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## Unreleased
+
+Bugfixes:
+* Specify encoding when opening files. Prevents `UnicodeDecodeError` on Windows
+  when the file contains non-CP1252 characters. (by @Avasam)
+
 ## 22.10.0
 
 Bugfixes:
@@ -149,7 +155,7 @@ Features:
 
 * extend Y001 to cover `ParamSpec` and `TypeVarTuple` in addition to `TypeVar`
 * detect usage of non-integer indices in `sys.version_info` checks
-* extend Y010 to check async functions in addition to normal functions 
+* extend Y010 to check async functions in addition to normal functions
 * extend Y010 to cover what was previously included in Y090 (disallow
   assignments in `__init__` methods) and Y091 (disallow `raise`
   statements). The previous checks were disabled by default.

--- a/pyi.py
+++ b/pyi.py
@@ -233,9 +233,9 @@ class PyiAwareFlakesChecker(FlakesChecker):
         # doctest does not process doctest within a doctest
         # classes within classes are processed.
         if (
-            self.withDoctest
-            and not self._in_doctest()
-            and not isinstance(self.scope, FunctionScope)
+            self.withDoctest and
+            not self._in_doctest() and
+            not isinstance(self.scope, FunctionScope)
         ):
             self.deferFunction(lambda: self.handleDoctests(node))
         for stmt in node.body:
@@ -340,9 +340,9 @@ def _is_object(node: ast.expr | None, name: str, *, from_: Container[str]) -> bo
     if isinstance(node_value, ast.Name):
         return node_value.id in from_
     return (
-        isinstance(node_value, ast.Attribute)
-        and isinstance(node_value.value, ast.Name)
-        and f"{node_value.value.id}.{node_value.attr}" in from_
+        isinstance(node_value, ast.Attribute) and
+        isinstance(node_value.value, ast.Name) and
+        f"{node_value.value.id}.{node_value.attr}" in from_
     )
 
 
@@ -395,9 +395,9 @@ def _get_name_of_class_if_from_modules(
         if isinstance(module_node, ast.Name) and module_node.id in modules:
             return classnode.attr
         if (
-            isinstance(module_node, ast.Attribute)
-            and isinstance(module_node.value, ast.Name)
-            and f"{module_node.value.id}.{module_node.attr}" in modules
+            isinstance(module_node, ast.Attribute) and
+            isinstance(module_node.value, ast.Name) and
+            f"{module_node.value.id}.{module_node.attr}" in modules
         ):
             return classnode.attr
     return None
@@ -542,9 +542,9 @@ def _has_bad_hardcoded_returns(
 
     if isinstance(method, ast.AsyncFunctionDef):
         return (
-            method_name == "__aenter__"
-            and _is_name(returns, classdef.name)
-            and not _is_decorated_with_final(classdef)
+            method_name == "__aenter__" and
+            _is_name(returns, classdef.name) and
+            not _is_decorated_with_final(classdef)
         )
 
     if method_name in _INPLACE_BINOP_METHODS:
@@ -562,8 +562,8 @@ def _has_bad_hardcoded_returns(
         return return_obj_name in {"Iterable", "Iterator"} and "Iterator" in bases
     elif method_name == "__aiter__":
         return (
-            return_obj_name in {"AsyncIterable", "AsyncIterator"}
-            and "AsyncIterator" in bases
+            return_obj_name in {"AsyncIterable", "AsyncIterator"} and
+            "AsyncIterator" in bases
         )
     return False
 
@@ -852,8 +852,8 @@ class PyiVisitor(ast.NodeVisitor):
 
         if module_name == "collections.abc":
             if (
-                "Set" in imported_names
-                and imported_names["Set"].asname != "AbstractSet"
+                "Set" in imported_names and
+                imported_names["Set"].asname != "AbstractSet"
             ):
                 self.error(node, Y025)
             return
@@ -907,15 +907,15 @@ class PyiVisitor(ast.NodeVisitor):
         if isinstance(assignment, (ast.Num, ast.Str, ast.Bytes)):
             return True
         if (
-            isinstance(assignment, ast.UnaryOp)
-            and isinstance(assignment.op, ast.USub)
-            and isinstance(assignment.operand, ast.Num)
+            isinstance(assignment, ast.UnaryOp) and
+            isinstance(assignment.op, ast.USub) and
+            isinstance(assignment.operand, ast.Num)
         ):
             return True
         if (
-            isinstance(assignment, (ast.Constant, ast.NameConstant))
-            and not isinstance(assignment, ast.Ellipsis)
-            and assignment.value is not None
+            isinstance(assignment, (ast.Constant, ast.NameConstant)) and
+            not isinstance(assignment, ast.Ellipsis) and
+            assignment.value is not None
         ):
             return True
 
@@ -997,9 +997,9 @@ class PyiVisitor(ast.NodeVisitor):
         and `X = None` (special-cased because it is so special).
         """
         if (
-            isinstance(assignment, (ast.Subscript, ast.BinOp))
-            or _is_Any(assignment)
-            or _is_None(assignment)
+            isinstance(assignment, (ast.Subscript, ast.BinOp)) or
+            _is_Any(assignment) or
+            _is_None(assignment)
         ):
             new_node = ast.AnnAssign(
                 target=target,
@@ -1036,9 +1036,9 @@ class PyiVisitor(ast.NodeVisitor):
     # 3.8+
     def visit_Constant(self, node: ast.Constant) -> None:
         if (
-            isinstance(node.value, str)
-            and node.value
-            and not self.string_literals_allowed.active
+            isinstance(node.value, str) and
+            node.value and
+            not self.string_literals_allowed.active
         ):
             self.error(node, Y020)
 
@@ -1283,9 +1283,9 @@ class PyiVisitor(ast.NodeVisitor):
                     return
                 elif (
                     # allow only [:1] and [:2]
-                    isinstance(slc.upper, ast.Num)
-                    and isinstance(slc.upper.n, int)
-                    and slc.upper.n in (1, 2)
+                    isinstance(slc.upper, ast.Num) and
+                    isinstance(slc.upper.n, int) and
+                    slc.upper.n in (1, 2)
                 ):
                     can_have_strict_equals = slc.upper.n
                 else:
@@ -1404,8 +1404,8 @@ class PyiVisitor(ast.NodeVisitor):
             if varargs:
                 varargs_annotation = varargs.annotation
                 if not (
-                    varargs_annotation is None
-                    or _is_builtins_object(varargs_annotation)
+                    varargs_annotation is None or
+                    _is_builtins_object(varargs_annotation)
                 ):
                     error_for_bad_exit_method(
                         f"Star-args in an {method_name} method "
@@ -1459,10 +1459,10 @@ class PyiVisitor(ast.NodeVisitor):
                     arg1_annotation
                 )
                 if not (
-                    is_union_with_None
-                    and isinstance(non_None_part, ast.Subscript)
-                    and _is_type_or_Type(non_None_part.value)
-                    and _is_BaseException(non_None_part.slice)
+                    is_union_with_None and
+                    isinstance(non_None_part, ast.Subscript) and
+                    _is_type_or_Type(non_None_part.value) and
+                    _is_BaseException(non_None_part.slice)
                 ):
                     error_for_bad_annotation(arg1_annotation, arg_number=1)
             else:
@@ -1571,9 +1571,9 @@ class PyiVisitor(ast.NodeVisitor):
         # 2). The method has the exact same signature as object.__str__/object.__repr__
         if method_name in {"__repr__", "__str__"}:
             if (
-                len(non_kw_only_args) == 1
-                and _is_object(returns, "str", from_={"builtins"})
-                and not any(_is_abstractmethod(deco) for deco in node.decorator_list)
+                len(non_kw_only_args) == 1 and
+                _is_object(returns, "str", from_={"builtins"}) and
+                not any(_is_abstractmethod(deco) for deco in node.decorator_list)
             ):
                 self.error(node, Y029)
 
@@ -1704,8 +1704,8 @@ class PyiVisitor(ast.NodeVisitor):
             # Ellipsis is fine. Str (docstrings) is not but we produce
             # tailored error message for it elsewhere.
             elif not (
-                isinstance(statement, ast.Expr)
-                and isinstance(statement.value, (ast.Ellipsis, ast.Str))
+                isinstance(statement, ast.Expr) and
+                isinstance(statement.value, (ast.Ellipsis, ast.Str))
             ):
                 self.error(statement, Y010)
 
@@ -1719,7 +1719,7 @@ class PyiVisitor(ast.NodeVisitor):
 
     def visit_arguments(self, node: ast.arguments) -> None:
         self.generic_visit(node)
-        args = node.args[-len(node.defaults) :]
+        args = node.args[-len(node.defaults):]
         for arg, default in chain(
             zip(args, node.defaults), zip(node.kwonlyargs, node.kw_defaults)
         ):
@@ -1774,7 +1774,7 @@ _TYPE_COMMENT_REGEX = re.compile(r"#\s*type:\s*(?!\s?ignore)([^#]+)(\s*#.*?)?$")
 
 
 def _check_for_type_comments(path: Path) -> Iterator[Error]:
-    stublines = path.read_text().splitlines()
+    stublines = path.read_text(encoding="UTF-8").splitlines()
     for lineno, line in enumerate(stublines, start=1):
         cleaned_line = line.strip()
 

--- a/setup.py
+++ b/setup.py
@@ -11,14 +11,14 @@ assert sys.version_info >= (3, 7, 0), "flake8-pyi requires Python 3.7+"
 
 
 current_dir = os.path.abspath(os.path.dirname(__file__))
-with open(os.path.join(current_dir, "README.md"), encoding="utf8") as ld_file:
+with open(os.path.join(current_dir, "README.md"), encoding="UTF-8") as ld_file:
     long_description = ld_file.read()
 
 
 _version_re = re.compile(r"__version__\s+=\s+(?P<version>.*)")
 
 
-with open(os.path.join(current_dir, "pyi.py"), "r") as f:
+with open(os.path.join(current_dir, "pyi.py"), "r", encoding="UTF-8") as f:
     version = _version_re.search(f.read()).group("version")
     version = str(ast.literal_eval(version))
 

--- a/tests/test_pyi_files.py
+++ b/tests/test_pyi_files.py
@@ -12,7 +12,7 @@ def test_pyi_file(path):
     flags = []
     expected_output = ""
 
-    with open(path) as file:
+    with open(path, encoding="UTF-8") as file:
         file_contents = file.read()
 
     for lineno, line in enumerate(file_contents.splitlines(), start=1):
@@ -26,7 +26,7 @@ def test_pyi_file(path):
 
         for match, next_match in zip_longest(error_codes, error_codes[1:]):
             end_pos = len(line) if next_match is None else next_match.start()
-            message = line[match.end() : end_pos].strip()
+            message = line[match.end(): end_pos].strip()
             expected_output += f"{path}:{lineno}: {match.group(1)}{message}\n"
 
     run_results = [


### PR DESCRIPTION
See https://peps.python.org/pep-0597/
This also happened to me on Windows in https://github.com/python/typeshed/pull/8879 because of mathematical unicode characters as part of the comments:
```py
(.venv) PS C:\Users\Avasam\Documents\Git\typeshed> flake8 .                    
Traceback (most recent call last):
  File "C:\Program Files\Python39\lib\runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "C:\Program Files\Python39\lib\runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "C:\Users\Avasam\Documents\Git\typeshed\.venv\Scripts\flake8.exe\__main__.py", line 7, in <module>
  File "C:\Users\Avasam\Documents\Git\typeshed\.venv\lib\site-packages\flake8\main\cli.py", line 22, in main
    app.run(argv)
  File "C:\Users\Avasam\Documents\Git\typeshed\.venv\lib\site-packages\flake8\main\application.py", line 363, in run
    self._run(argv)
  File "C:\Users\Avasam\Documents\Git\typeshed\.venv\lib\site-packages\flake8\main\application.py", line 351, in _run
    self.run_checks()
  File "C:\Users\Avasam\Documents\Git\typeshed\.venv\lib\site-packages\flake8\main\application.py", line 264, in run_checks
    self.file_checker_manager.run()
  File "C:\Users\Avasam\Documents\Git\typeshed\.venv\lib\site-packages\flake8\checker.py", line 323, in run
    self.run_serial()
  File "C:\Users\Avasam\Documents\Git\typeshed\.venv\lib\site-packages\flake8\checker.py", line 307, in run_serial
    checker.run_checks()
  File "C:\Users\Avasam\Documents\Git\typeshed\.venv\lib\site-packages\flake8\checker.py", line 589, in run_checks
    self.run_ast_checks()
  File "C:\Users\Avasam\Documents\Git\typeshed\.venv\lib\site-packages\flake8\checker.py", line 494, in run_ast_checks
    for (line_number, offset, text, _) in runner:
  File "C:\Users\Avasam\Documents\Git\typeshed\.venv\lib\site-packages\pyi.py", line 1811, in run
    yield from _check_for_type_comments(path)
  File "C:\Users\Avasam\Documents\Git\typeshed\.venv\lib\site-packages\pyi.py", line 1777, in _check_for_type_comments
    stublines = path.read_text().splitlines()
  File "C:\Program Files\Python39\lib\pathlib.py", line 1267, in read_text     
    return f.read()
  File "C:\Program Files\Python39\lib\encodings\cp1252.py", line 23, in decode 
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 176166: 
character maps to <undefined>
```

There are linters to catch this, namely [pylint (unspecified-encoding)](https://pylint.pycqa.org/en/latest/user_guide/messages/warning/unspecified-encoding.html), [flake8-encodings](https://pypi.org/project/flake8-encodings/) and [flake8-file-encoding](https://pypi.org/project/flake8-file-encoding/). I have tried both flake8 plugins mentioned and they gave me the same results, other than slightly different error messages:
![image](https://user-images.githubusercontent.com/1350584/195191981-4be0c6e2-0adf-433e-ba7b-081e2834ab5a.png)
