### PR TITLE
Minor improvements to workflow files

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,6 +10,13 @@ on:
 permissions:
   contents: read
 
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: 1
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   mypy:
     name: mypy
@@ -17,29 +24,37 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        python-version: ['3.7', '3.10']
+        python-version: ['3.7', '3.11']
       fail-fast: false
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        cache: pip
+        cache-dependency-path: requirements-dev.txt
     - run: pip install -r requirements-dev.txt
     - run: mypy pyi.py
+
   flake8:
     name: flake8
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
+        python-version: "3.11"
+        cache: pip
+        cache-dependency-path: |
+          requirements-dev.txt
+          setup.py
     # flake8 not in requirements-dev.txt, because versions specified in setup.py are complicated
     - run: pip install -e .
     - run: pip install -r requirements-dev.txt
     - run: |
         flake8 $(git ls-files | grep 'py$')
+
   tests:
     name: pytest suite
     timeout-minutes: 10
@@ -47,44 +62,56 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11-dev']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
       fail-fast: false
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        cache: pip
+        cache-dependency-path: |
+          requirements-dev.txt
+          setup.py
     - run: pip install -e .
     - run: pip install -r requirements-dev.txt
     - run: python3 -m pytest -vv
+
   tests-flake8-v4:
     name: pytest suite with flake8 v4
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
       with:
         # Run on Python 3.7, as the importlib_metadata compatibility problems with flake8 v5
         # are much less on Python 3.8+, where importlib.metadata is available in the stdlib
         python-version: 3.7
+        cache: pip
+        cache-dependency-path: |
+          requirements-dev.txt
+          setup.py
     - run: pip install "flake8<5"
     - run: pip install -e .
     - run: pip install -r requirements-dev.txt
     - run: python3 -m pytest -vv
+
   check-typeshed:
     name: typeshed_primer
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+    - uses: actions/checkout@v3
       with:
         repository: python/typeshed
         path: typeshed
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
+        python-version: "3.11"
+        cache: pip
+        cache-dependency-path: setup.py
     - run: pip install -e .
     - run: |
         cd typeshed && flake8

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,11 +13,11 @@ jobs:
     name: Build and publish Python distributions to PyPI
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: "3.10"
     - name: Install pypa/build
       run: >-
         python -m


### PR DESCRIPTION
- Upgrade the versions of various actions we're using, to avoid deprecation warnings in CI
- Disable the pip version check
- Cancel old CI runs if new pushes are made to a PR branch
- Cache pip in CI
- Update the Python versions we're running on (`3.11-dev` -> `3.11`, etc.)