### PR TITLE
Sync `requirements-dev.txt` with pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
       - id: black
         language_version: python3.9
   - repo: https://github.com/pycqa/isort
-    rev: 5.11.1  # must match requirements-dev.txt
+    rev: 5.11.2  # must match requirements-dev.txt
     hooks:
       - id: isort
         name: isort (python)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
-black==22.10.0      # Must match .pre-commit-config.yaml
+black==22.12.0      # Must match .pre-commit-config.yaml
 pytest==7.2.0
 mypy==0.991
-isort==5.10.1      # Must match .pre-commit-config.yaml
+isort==5.11.2      # Must match .pre-commit-config.yaml
 flake8-bugbear==22.10.27
 flake8-noqa==1.3.0
 types-pyflakes<4


### PR DESCRIPTION
And bump isort to 5.11.2 while we're at it