### PR TITLE
Simplify how we specify 'dev dependencies'

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -35,8 +35,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
-          cache-dependency-path: requirements-dev.txt
-      - run: pip install -r requirements-dev.txt
+          cache-dependency-path: pyproject.toml
+      - run: pip install -e .[dev]
       - run: mypy pyi.py
 
   flake8:
@@ -49,12 +49,8 @@ jobs:
         with:
           python-version: "3.11"
           cache: pip
-          cache-dependency-path: |
-            requirements-dev.txt
-            pyproject.toml
-      # flake8 not in requirements-dev.txt, because versions specified in pyproject.toml are complicated
-      - run: pip install -e .
-      - run: pip install -r requirements-dev.txt
+          cache-dependency-path: pyproject.toml
+      - run: pip install -e .[dev]
       - run: |
           flake8 $(git ls-files | grep 'py$') --color always
 
@@ -73,11 +69,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
-          cache-dependency-path: |
-            requirements-dev.txt
-            pyproject.toml
-      - run: pip install -e .
-      - run: pip install -r requirements-dev.txt
+          cache-dependency-path: pyproject.toml
+      - run: pip install -e .[dev]
       - run: python3 -m pytest -vv
 
   tests-flake8-v4:
@@ -92,10 +85,7 @@ jobs:
           # are much less on Python 3.8+, where importlib.metadata is available in the stdlib
           python-version: 3.7
           cache: pip
-          cache-dependency-path: |
-            requirements-dev.txt
-            pyproject.toml
+          cache-dependency-path: pyproject.toml
       - run: pip install "flake8<5"
-      - run: pip install -e .
-      - run: pip install -r requirements-dev.txt
+      - run: pip install -e .[dev]
       - run: python3 -m pytest -vv

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,11 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.12.0 # must match requirements-dev.txt
+    rev: 22.12.0 # must match pyproject.toml
     hooks:
       - id: black
         language_version: python3.9
   - repo: https://github.com/pycqa/isort
-    rev: 5.11.4 # must match requirements-dev.txt
+    rev: 5.11.4 # must match pyproject.toml
     hooks:
       - id: isort
         name: isort (python)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,8 +25,7 @@ however, we advise setting up a virtual environment first:
 
     $ python3 -m venv env
     $ source env/bin/activate
-    $ pip install -r requirements-dev.txt
-    $ pip install -e .
+    $ pip install -e .[dev]
 
 To format your code with `isort` and `black`, run:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,17 @@ dependencies = [
 "Bug Tracker" = "https://github.com/PyCQA/flake8-pyi/issues"
 "Changelog" = "https://github.com/PyCQA/flake8-pyi/blob/master/CHANGELOG.md"
 
+[project.optional-dependencies]
+dev = [
+    "black==22.12.0",            # Must match .pre-commit-config.yaml
+    "flake8-bugbear==22.10.27",
+    "flake8-noqa==1.3.0",
+    "isort==5.11.4",             # Must match .pre-commit-config.yaml
+    "mypy==0.991",
+    "pytest==7.2.1",
+    "types-pyflakes<4",
+]
+
 [project.entry-points]
 "flake8.extension" = {Y0 = "pyi:PyiTreeChecker"}
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,0 @@
-black==22.12.0      # Must match .pre-commit-config.yaml
-pytest==7.2.0
-mypy==0.991
-isort==5.11.4      # Must match .pre-commit-config.yaml
-flake8-bugbear==22.10.27
-flake8-noqa==1.3.0
-types-pyflakes<4
-ast_decompiler>=0.7.0,<1.0; python_version < '3.9'


### PR DESCRIPTION
Use a "dev" extra in `pyproject.toml`, eliminating the need for a separate `requirements-dev.txt` file.

Also bump the pinned version of pytest while we're at it. (The version of flake8-bugbear we have pinned is also not the latest, but the latest version finds a bunch of supposed issues with our code, so let's do that one separately.)