### PR TITLE
Ban importing `Match` and `Pattern` from `typing` (import from `re` instead)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,12 @@ Other changes:
   [Avasam](https://github.com/Avasam)
 * Several changes have been made to error codes relating to imports:
     * The Y027 error code has been removed.
-    * Errors that used to result in Y027 being emitted will now result in Y022
-      being emitted.
-    * Some errors that used to result in Y023 being emitted will also now result
-      in Y022 being emitted.
+    * All errors that used to result in Y027 being emitted now result in Y022
+      being emitted instead.
+    * Some errors that used to result in Y023 being emitted now result
+      in Y022 being emitted instead.
+    * `typing.Match` and `typing.Pattern` have been added to the list of imports
+      banned by Y022. Use `re.Match` and `re.Pattern` instead.
 * flake8-pyi no longer supports stub files that aim to support Python 2. If your
   stubs need to support Python 2, pin flake8-pyi to 22.11.0 or lower.
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ currently emitted:
 | Y019 | Certain kinds of methods should use `_typeshed.Self` instead of defining custom `TypeVar`s for their return annotation. This check currently applies for instance methods that return `self`, class methods that return an instance of `cls`, and `__new__` methods.
 | Y020 | Quoted annotations should never be used in stubs.
 | Y021 | Docstrings should not be included in stubs.
-| Y022 | The `typing` and `typing_extensions` modules include various aliases to stdlib objects. Use these as little as possible (e.g. prefer `builtins.list` over `typing.List`, `collections.OrderedDict` over `typing.OrderedDict`, etc.).
+| Y022 | The `typing` and `typing_extensions` modules include various aliases to stdlib objects. Use these as little as possible (e.g. prefer `builtins.list` over `typing.List`, `collections.Counter` over `typing.Counter`, etc.).
 | Y023 | Where there is no detriment to backwards compatibility, import objects such as `ClassVar` and `NoReturn` from `typing` rather than `typing_extensions`.
 | Y024 | Use `typing.NamedTuple` instead of `collections.namedtuple`, as it allows for more precise type inference.
 | Y025 | Always alias `collections.abc.Set` when importing it, so as to avoid confusion with `builtins.set`.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ currently emitted:
 | Y019 | Certain kinds of methods should use `_typeshed.Self` instead of defining custom `TypeVar`s for their return annotation. This check currently applies for instance methods that return `self`, class methods that return an instance of `cls`, and `__new__` methods.
 | Y020 | Quoted annotations should never be used in stubs.
 | Y021 | Docstrings should not be included in stubs.
-| Y022 | Use typing-module aliases to stdlib objects as little as possible (e.g. `builtins.list` over `typing.List`, `collections.OrderedDict` over `typing_extensions.OrderedDict`, etc.).
+| Y022 | The `typing` and `typing_extensions` modules include various aliases to stdlib objects. Use these as little as possible (e.g. prefer `builtins.list` over `typing.List`, `collections.OrderedDict` over `typing.OrderedDict`, etc.).
 | Y023 | Where there is no detriment to backwards compatibility, import objects such as `ClassVar` and `NoReturn` from `typing` rather than `typing_extensions`.
 | Y024 | Use `typing.NamedTuple` instead of `collections.namedtuple`, as it allows for more precise type inference.
 | Y025 | Always alias `collections.abc.Set` when importing it, so as to avoid confusion with `builtins.set`.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ currently emitted:
 | Y019 | Certain kinds of methods should use `_typeshed.Self` instead of defining custom `TypeVar`s for their return annotation. This check currently applies for instance methods that return `self`, class methods that return an instance of `cls`, and `__new__` methods.
 | Y020 | Quoted annotations should never be used in stubs.
 | Y021 | Docstrings should not be included in stubs.
-| Y022 | Imports linting: use typing-module aliases to stdlib objects as little as possible (e.g. `builtins.list` over `typing.List`, `collections.Counter` over `typing.Counter`, etc.).
+| Y022 | Use typing-module aliases to stdlib objects as little as possible (e.g. `builtins.list` over `typing.List`, `collections.OrderedDict` over `typing_extensions.OrderedDict`, etc.).
 | Y023 | Where there is no detriment to backwards compatibility, import objects such as `ClassVar` and `NoReturn` from `typing` rather than `typing_extensions`.
 | Y024 | Use `typing.NamedTuple` instead of `collections.namedtuple`, as it allows for more precise type inference.
 | Y025 | Always alias `collections.abc.Set` when importing it, so as to avoid confusion with `builtins.set`.

--- a/pyi.py
+++ b/pyi.py
@@ -83,9 +83,12 @@ _BAD_Y022_IMPORTS: dict[str, tuple[str, str | None]] = {
     "typing.Set": ("set", "T"),
     "typing.Tuple": ("tuple", "Foo, Bar"),
     "typing.Type": ("type", _TYPE_SLICE),
-    # Typing aliases for contextlib
+    # typing aliases for contextlib
     "typing.ContextManager": ("contextlib.AbstractContextManager", "T"),
     "typing.AsyncContextManager": ("contextlib.AbstractAsyncContextManager", "T"),
+    # typing aliases for re
+    "typing.Match": ("re.Match", "T"),
+    "typing.Pattern": ("re.Pattern", "T"),
     # typing_extensions aliases for collections
     "typing_extensions.Counter": ("collections.Counter", _COUNTER_SLICE),
     "typing_extensions.Deque": ("collections.deque", "T"),

--- a/tests/imports.pyi
+++ b/tests/imports.pyi
@@ -7,6 +7,7 @@
 from __future__ import annotations  # Y044 "from __future__ import annotations" has no effect in stub files.
 
 # GOOD IMPORTS
+import re
 import typing
 import typing_extensions
 import collections
@@ -38,6 +39,7 @@ from collections.abc import (
     MutableSequence,
     ByteString
 )
+from re import Match, Pattern
 # Things that are of no use for stub files are intentionally omitted.
 from typing import (
     Any,
@@ -55,8 +57,6 @@ from typing import (
     BinaryIO,
     IO,
     NamedTuple,
-    Match,
-    Pattern,
     TextIO,
     AnyStr,
     NewType,
@@ -116,6 +116,8 @@ from typing import Collection  # Y022 Use "collections.abc.Collection[T]" instea
 from typing import AsyncGenerator  # Y022 Use "collections.abc.AsyncGenerator[YieldType, SendType]" instead of "typing.AsyncGenerator[YieldType, SendType]" (PEP 585 syntax)
 from typing import Reversible  # Y022 Use "collections.abc.Reversible[T]" instead of "typing.Reversible[T]" (PEP 585 syntax)
 from typing import Generator  # Y022 Use "collections.abc.Generator[YieldType, SendType, ReturnType]" instead of "typing.Generator[YieldType, SendType, ReturnType]" (PEP 585 syntax)
+from typing import Match  # Y022 Use "re.Match[T]" instead of "typing.Match[T]" (PEP 585 syntax)
+from typing import Pattern  # Y022 Use "re.Pattern[T]" instead of "typing.Pattern[T]" (PEP 585 syntax)
 
 # BAD IMPORTS (Y023 code)
 from typing_extensions import ClassVar  # Y023 Use "typing.ClassVar[T]" instead of "typing_extensions.ClassVar[T]"
@@ -129,6 +131,7 @@ from typing import Text  # Y039 Use "str" instead of "typing.Text"
 
 # GOOD ATTRIBUTE ACCESS
 foo: typing.SupportsIndex
+baz: re.Pattern[str]
 
 @typing_extensions.final
 def bar(arg: collections.abc.Sized) -> typing_extensions.Literal[True]: ...
@@ -143,6 +146,7 @@ h: typing_extensions.Awaitable[float]  # Y022 Use "collections.abc.Awaitable[T]"
 i: typing_extensions.ContextManager[None]  # Y022 Use "contextlib.AbstractContextManager[T]" instead of "typing_extensions.ContextManager[T]" (PEP 585 syntax)
 k: typing_extensions.OrderedDict[int, str]  # Y022 Use "collections.OrderedDict[KeyType, ValueType]" instead of "typing_extensions.OrderedDict[KeyType, ValueType]" (PEP 585 syntax)
 l: typing.ContextManager  # Y022 Use "contextlib.AbstractContextManager[T]" instead of "typing.ContextManager[T]" (PEP 585 syntax)
+n: typing.Match[bytes]  # Y022 Use "re.Match[T]" instead of "typing.Match[T]" (PEP 585 syntax)
 
 def func1() -> typing.Counter[float]: ...  # Y022 Use "collections.Counter[KeyType]" instead of "typing.Counter[KeyType]" (PEP 585 syntax)
 def func2(c: typing.AsyncContextManager[None]) -> None: ...  # Y022 Use "contextlib.AbstractAsyncContextManager[T]" instead of "typing.AsyncContextManager[T]" (PEP 585 syntax)


### PR DESCRIPTION
Closes #46