### PR TITLE
Improve pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,11 +18,6 @@ repos:
     hooks:
       - id: isort
         name: isort (python)
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.0-alpha.4
-    hooks:
-      - id: prettier
-        types_or: [yaml]
 
 ci:
   autofix_commit_msg: "[pre-commit.ci] auto fixes from pre-commit.com hooks"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,19 +1,32 @@
 repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0  # must match pyproject.toml
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-toml
+      - id: check-merge-conflict
+      - id: mixed-line-ending
   - repo: https://github.com/psf/black
     rev: 22.12.0 # must match pyproject.toml
     hooks:
       - id: black
-        language_version: python3.9
+        language_version: python3.7
   - repo: https://github.com/pycqa/isort
     rev: 5.11.4 # must match pyproject.toml
     hooks:
       - id: isort
         name: isort (python)
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.0.0-alpha.4
+    hooks:
+      - id: prettier
+        types_or: [yaml]
 
 ci:
   autofix_commit_msg: "[pre-commit.ci] auto fixes from pre-commit.com hooks"
   autofix_prs: true
   autoupdate_commit_msg: "[pre-commit.ci] pre-commit autoupdate"
-  autoupdate_schedule: weekly
-  skip: []
+  autoupdate_schedule: quarterly
   submodules: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ The plugin consists of a single file: `pyi.py`. Tests are run using `pytest`, an
 found in the `tests` folder.
 
 PRs that make user-visible changes should generally add a short description of the change
-to the `CHANGELOG.md` file in the repository root. 
+to the `CHANGELOG.md` file in the repository root.
 
 
 ## Tests and formatting

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ dev = [
     "flake8-noqa==1.3.0",
     "isort==5.11.4",             # Must match .pre-commit-config.yaml
     "mypy==0.991",
+    "pre-commit-hooks==4.4.0",   # Must match .pre-commit-config.yaml
     "pytest==7.2.1",
     "types-pyflakes<4",
 ]


### PR DESCRIPTION
- Change the bot schedule from weekly to quarterly, to reduce noisy PRs.
- Change the `black` target language version to 3.7, since we support 3.7.
- ~~Add `prettier` as a pre-commit hook, to auto-format YAML files.~~
- Add a bunch of cheap, useful hooks from https://github.com/pre-commit/pre-commit-hooks. `trailing-whitespace`, `end-of-file-fixer` and `mixed-line-ending` are all autofix hooks. `check-yaml`, `check-toml` and `check-merge-conflict` are not, but are useful hooks for detecting problems early.