### PR TITLE
`isort` config: set `skip_gitignore = true`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ path = "pyi.py"
 profile = "black"
 combine_as_imports = true
 skip = ["tests/imports.pyi"]
+skip_gitignore = true
 
 [tool.black]
 target-version = ['py37']


### PR DESCRIPTION
This means `isort` won't try to fix everything in `site-packages` if you have a virtual environment in an `env/` directory and are foolish enough to run `isort .` locally 🙃