### PR TITLE
`typeshed_primer`: Add a newline before the final backticks

### DIFF
--- a/.github/scripts/typeshed_primer_post_comment.js
+++ b/.github/scripts/typeshed_primer_post_comment.js
@@ -16,7 +16,7 @@ module.exports = async ({ github, context }) => {
   }
 
   const body = data.trim()
-    ? '⚠ Flake8 diff showing the effect of this PR on typeshed: \n```diff\n' + data + '```'
+    ? '⚠ Flake8 diff showing the effect of this PR on typeshed: \n```diff\n' + data + '\n```'
     : 'This change has no effect on typeshed. 🤖🎉'
   const issue_number = parseInt(fs.readFileSync("pr_number.txt", { encoding: "utf8" }))
   await github.rest.issues.createComment({

--- a/.github/workflows/typeshed_primer.yml
+++ b/.github/workflows/typeshed_primer.yml
@@ -39,17 +39,18 @@ jobs:
           python-version: "3.11"
           cache: pip
           cache-dependency-path: new_plugin/pyproject.toml
+      - run: pip install flake8-noqa
       # We cd so that "old_plugin"/"new_plugin"/typeshed" don't appear in the error path
       - name: flake8 typeshed using target branch
         run: |
           cd old_plugin
-          pip install flake8-noqa -e .
+          pip install -e .
           cd ../typeshed
           flake8 --exit-zero --color never --output-file ../old_errors.txt
       - name: flake8 typeshed using PR branch
         run: |
           cd new_plugin
-          pip install flake8-noqa -e .
+          pip install -e .
           cd ../typeshed
           flake8 --exit-zero --color never --output-file ../new_errors.txt
       - name: Get diff between the two runs


### PR DESCRIPTION
The formatting isn't currently quite correct: see e.g. https://github.com/PyCQA/flake8-pyi/pull/336#issuecomment-1398747766

Also, there's no need to install flake8-noqa twice in the workflow; we can just do it once.