### PR TITLE
Upgrade to isort 5.12.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       - id: black
         language_version: python3.7
   - repo: https://github.com/pycqa/isort
-    rev: 5.11.4 # must match pyproject.toml
+    rev: 5.12.0 # must match pyproject.toml
     hooks:
       - id: isort
         name: isort (python)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,12 +60,12 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "black==22.12.0",            # Must match .pre-commit-config.yaml
+    "black==22.12.0",                         # Must match .pre-commit-config.yaml
     "flake8-bugbear==23.1.14",
     "flake8-noqa==1.3.0",
     "isort==5.12.0; python_version >= '3.8'", # Must match .pre-commit-config.yaml
     "mypy==0.991",
-    "pre-commit-hooks==4.4.0",   # Must match .pre-commit-config.yaml
+    "pre-commit-hooks==4.4.0",                # Must match .pre-commit-config.yaml
     "pytest==7.2.1",
     "types-pyflakes<4",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ dev = [
     "black==22.12.0",            # Must match .pre-commit-config.yaml
     "flake8-bugbear==23.1.14",
     "flake8-noqa==1.3.0",
-    "isort==5.11.4",             # Must match .pre-commit-config.yaml
+    "isort==5.12.0",             # Must match .pre-commit-config.yaml
     "mypy==0.991",
     "pre-commit-hooks==4.4.0",   # Must match .pre-commit-config.yaml
     "pytest==7.2.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ dev = [
     "black==22.12.0",            # Must match .pre-commit-config.yaml
     "flake8-bugbear==23.1.14",
     "flake8-noqa==1.3.0",
-    "isort==5.12.0",             # Must match .pre-commit-config.yaml
+    "isort==5.12.0; python_version >= '3.8'", # Must match .pre-commit-config.yaml
     "mypy==0.991",
     "pre-commit-hooks==4.4.0",   # Must match .pre-commit-config.yaml
     "pytest==7.2.1",


### PR DESCRIPTION
isort <5.12.0 is incompatible with the latest version of `poetry-core`, which has been causing many failures in pre-commit across many repos. (See PyCQA/isort#2077 for more details.)