### PR TITLE
Increase max number length to 10 characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## Unreleased
+
+Other changes:
+* Y015: Increase the maximum character length of literal numbers from 7 to 10.
+  Allowing hexadecimal representation of 32-bit integers.
+  Contributed by [Avasam](https://github.com/Avasam).
+
 ## 23.1.1
 
 New error codes:

--- a/pyi.py
+++ b/pyi.py
@@ -729,7 +729,11 @@ def _is_valid_default_value_with_annotation(node: ast.expr) -> bool:
         return len(str(node.s)) <= 50
 
     def _is_valid_Num(node: ast.expr) -> TypeGuard[ast.Num]:
-        return isinstance(node, ast.Num) and len(str(node.n)) <= 7
+        # The maximum character limit is arbitrary, but here's what it's based on:
+        # Hex representation of 32-bit integers tend to be 10 chars.
+        # So is the decimal representation of the maximum positive signed 32-bit integer.
+        # 0xFFFFFFFF --> 4294967295
+        return isinstance(node, ast.Num) and len(str(node.n)) <= 10
 
     # Positive ints, positive floats, positive complex numbers with no real part
     if _is_valid_Num(node):

--- a/tests/attribute_annotations.pyi
+++ b/tests/attribute_annotations.pyi
@@ -54,10 +54,10 @@ field22: Final = {"foo": 5}  # Y015 Only simple default values are allowed for a
 field23 = "foo" + "bar"  # Y015 Only simple default values are allowed for assignments
 field24 = b"foo" + b"bar"  # Y015 Only simple default values are allowed for assignments
 field25 = 5 * 5  # Y015 Only simple default values are allowed for assignments
-field26: int = 0xFFFFFFFFF # Y015 Only simple default values are allowed for assignments
-field27: int = 12345678901 # Y015 Only simple default values are allowed for assignments
-field28: int = -0xFFFFFFFFF # Y015 Only simple default values are allowed for assignments
-field29: int = -12345678901 # Y015 Only simple default values are allowed for assignments
+field26: int = 0xFFFFFFFFF  # Y015 Only simple default values are allowed for assignments
+field27: int = 12345678901  # Y015 Only simple default values are allowed for assignments
+field28: int = -0xFFFFFFFFF  # Y015 Only simple default values are allowed for assignments
+field29: int = -12345678901  # Y015 Only simple default values are allowed for assignments
 
 class Foo:
     field1: int

--- a/tests/attribute_annotations.pyi
+++ b/tests/attribute_annotations.pyi
@@ -13,6 +13,10 @@ field1: int
 field2: int = ...
 field3 = ...  # type: int  # Y033 Do not use type comments in stubs (e.g. use "x: int" instead of "x = ... # type: int")
 field4: int = 0
+field41: int = 0xFFFFFFFF
+field42: int = 1234567890
+field43: int = -0xFFFFFFFF
+field44: int = -1234567890
 field5 = 0  # type: int  # Y033 Do not use type comments in stubs (e.g. use "x: int" instead of "x = ... # type: int")  # Y052 Need type annotation for "field5"
 field6 = 0  # Y052 Need type annotation for "field6"
 field7 = b""  # Y052 Need type annotation for "field7"
@@ -50,12 +54,20 @@ field22: Final = {"foo": 5}  # Y015 Only simple default values are allowed for a
 field23 = "foo" + "bar"  # Y015 Only simple default values are allowed for assignments
 field24 = b"foo" + b"bar"  # Y015 Only simple default values are allowed for assignments
 field25 = 5 * 5  # Y015 Only simple default values are allowed for assignments
+field26: int = 0xFFFFFFFFF # Y015 Only simple default values are allowed for assignments
+field27: int = 12345678901 # Y015 Only simple default values are allowed for assignments
+field28: int = -0xFFFFFFFFF # Y015 Only simple default values are allowed for assignments
+field29: int = -12345678901 # Y015 Only simple default values are allowed for assignments
 
 class Foo:
     field1: int
     field2: int = ...
     field3 = ...  # type: int  # Y033 Do not use type comments in stubs (e.g. use "x: int" instead of "x = ... # type: int")
     field4: int = 0
+    field41: int = 0xFFFFFFFF
+    field42: int = 1234567890
+    field43: int = -0xFFFFFFFF
+    field44: int = -1234567890
     field5 = 0  # type: int  # Y033 Do not use type comments in stubs (e.g. use "x: int" instead of "x = ... # type: int")  # Y052 Need type annotation for "field5"
     field6 = 0  # Y052 Need type annotation for "field6"
     field7 = b""  # Y052 Need type annotation for "field7"
@@ -86,6 +98,10 @@ class Foo:
     field24 = "foo" + "bar"  # Y015 Only simple default values are allowed for assignments
     field25 = b"foo" + b"bar"  # Y015 Only simple default values are allowed for assignments
     field26 = 5 * 5  # Y015 Only simple default values are allowed for assignments
+    field27 = 0xFFFFFFFFF  # Y015 Only simple default values are allowed for assignments
+    field28 = 12345678901  # Y015 Only simple default values are allowed for assignments
+    field29 = -0xFFFFFFFFF  # Y015 Only simple default values are allowed for assignments
+    field30 = -12345678901  # Y015 Only simple default values are allowed for assignments
 
     Field95: TypeAlias = None
     Field96: TypeAlias = int | None


### PR DESCRIPTION
Y015: Increase the maximum character length of literal numbers from 7 to 10.
  Allowing hexadecimal representation of 32-bit integers.

See https://github.com/python/typeshed/pull/9642#issuecomment-1411163229 for the use-case in typeshed that brought this up.
CC @AlexWaygood  and @JelleZijlstra 