### PR TITLE
Do not recommend use of collections.abc.ByteString

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## Unreleased
+
+* Y027: No longer recommend replacing `typing.ByteString` with
+  `collections.abc.ByteString`, since their semantics do not correspond
+  and `collections.abc.ByteString`'s semantics are terrible to begin with.
+
 ## 23.1.2
 
 * Y011/Y014/Y015: Increase the maximum character length of literal numbers

--- a/pyi.py
+++ b/pyi.py
@@ -105,8 +105,8 @@ _BAD_Y022_IMPORTS: dict[str, tuple[str, str | None]] = {
     ),
     # typing aliases for collections.abc
     # typing.AbstractSet is deliberately omitted (special-cased elsewhere)
+    # typing.ByteString is also deliberately omitted (https://github.com/python/cpython/issues/102092)
     # If the second element of the tuple is `None`, it signals that the object shouldn't be parameterized
-    "typing.ByteString": ("collections.abc.ByteString", None),
     "typing.Collection": ("collections.abc.Collection", "T"),
     "typing.ItemsView": ("collections.abc.ItemsView", _MAPPING_SLICE),
     "typing.KeysView": ("collections.abc.KeysView", "KeyType"),

--- a/tests/imports.pyi
+++ b/tests/imports.pyi
@@ -39,6 +39,7 @@ from collections.abc import (
     MutableSequence,
     ByteString
 )
+from typing import ByteString
 from re import Match, Pattern
 # Things that are of no use for stub files are intentionally omitted.
 from typing import (
@@ -93,7 +94,6 @@ from typing import ContextManager  # Y022 Use "contextlib.AbstractContextManager
 from typing import OrderedDict  # Y022 Use "collections.OrderedDict[KeyType, ValueType]" instead of "typing.OrderedDict[KeyType, ValueType]" (PEP 585 syntax)
 from typing_extensions import OrderedDict  # Y022 Use "collections.OrderedDict[KeyType, ValueType]" instead of "typing_extensions.OrderedDict[KeyType, ValueType]" (PEP 585 syntax)
 from typing import Callable  # Y022 Use "collections.abc.Callable" instead of "typing.Callable" (PEP 585 syntax)
-from typing import ByteString
 from typing import Container  # Y022 Use "collections.abc.Container[T]" instead of "typing.Container[T]" (PEP 585 syntax)
 from typing import Hashable  # Y022 Use "collections.abc.Hashable" instead of "typing.Hashable" (PEP 585 syntax)
 from typing import ItemsView  # Y022 Use "collections.abc.ItemsView[KeyType, ValueType]" instead of "typing.ItemsView[KeyType, ValueType]" (PEP 585 syntax)

--- a/tests/imports.pyi
+++ b/tests/imports.pyi
@@ -93,7 +93,7 @@ from typing import ContextManager  # Y022 Use "contextlib.AbstractContextManager
 from typing import OrderedDict  # Y022 Use "collections.OrderedDict[KeyType, ValueType]" instead of "typing.OrderedDict[KeyType, ValueType]" (PEP 585 syntax)
 from typing_extensions import OrderedDict  # Y022 Use "collections.OrderedDict[KeyType, ValueType]" instead of "typing_extensions.OrderedDict[KeyType, ValueType]" (PEP 585 syntax)
 from typing import Callable  # Y022 Use "collections.abc.Callable" instead of "typing.Callable" (PEP 585 syntax)
-from typing import ByteString  # Y022 Use "collections.abc.ByteString" instead of "typing.ByteString" (PEP 585 syntax)
+from typing import ByteString
 from typing import Container  # Y022 Use "collections.abc.Container[T]" instead of "typing.Container[T]" (PEP 585 syntax)
 from typing import Hashable  # Y022 Use "collections.abc.Hashable" instead of "typing.Hashable" (PEP 585 syntax)
 from typing import ItemsView  # Y022 Use "collections.abc.ItemsView[KeyType, ValueType]" instead of "typing.ItemsView[KeyType, ValueType]" (PEP 585 syntax)


### PR DESCRIPTION
It is highly confusing, its isinstance / issubclass behaviour does not match the documentation of typing.ByteString, and we hope to deprecate it

See https://github.com/python/cpython/issues/102092