### PR TITLE
Fix some issues flagged by pyright

### DIFF
--- a/pyi.py
+++ b/pyi.py
@@ -34,8 +34,6 @@ else:
 
 
 if TYPE_CHECKING:
-    from _ast import _Slice
-
     # We don't have typing_extensions as a runtime dependency,
     # but all our annotations are stringized due to __future__ annotations,
     # and mypy thinks typing_extensions is part of the stdlib.
@@ -666,7 +664,7 @@ def _analyse_union(members: Sequence[ast.expr]) -> UnionAnalysis:
     non_literals_in_union = False
     members_by_dump: defaultdict[str, list[ast.expr]] = defaultdict(list)
     builtins_classes_in_union: set[str] = set()
-    literals_in_union: list[_Slice] = []
+    literals_in_union = []
     combined_literal_members: list[_LiteralMember] = []
 
     for member in members:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,3 +100,35 @@ allow_incomplete_defs = true
 
 [tool.pytest.ini_options]
 addopts = "--doctest-modules"
+
+[tool.pyright]
+include = ["*.py"]
+venv = "env"
+pythonVersion = "3.7"
+typeCheckingMode = "strict"
+
+# Extra strict settings
+reportMissingModuleSource = "error"
+reportShadowedImports = "error"
+reportCallInDefaultInitializer = "error"
+reportUninitializedInstanceVariable = "error"
+reportUnnecessaryTypeIgnoreComment = "error"
+
+# Leave "type: ignore" comments to mypy
+enableTypeIgnoreComments = false
+
+# Runtime libraries used are not all py.typed
+useLibraryCodeForTypes = true
+
+# Overly strict settings with false positives
+reportMissingSuperCall = "none"
+reportImplicitStringConcatenation = "none"
+
+# Already flagged by mypy
+reportMissingTypeStubs = "none"
+
+# Strict settings we might want to work towards enabling at some point
+reportUnknownParameterType = false
+reportMissingParameterType = false
+reportUnknownMemberType = false
+reportUnknownArgumentType = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,35 +100,3 @@ allow_incomplete_defs = true
 
 [tool.pytest.ini_options]
 addopts = "--doctest-modules"
-
-[tool.pyright]
-include = ["*.py"]
-venv = "env"
-pythonVersion = "3.7"
-typeCheckingMode = "strict"
-
-# Extra strict settings
-reportMissingModuleSource = "error"
-reportShadowedImports = "error"
-reportCallInDefaultInitializer = "error"
-reportUninitializedInstanceVariable = "error"
-reportUnnecessaryTypeIgnoreComment = "error"
-
-# Leave "type: ignore" comments to mypy
-enableTypeIgnoreComments = false
-
-# Runtime libraries used are not all py.typed
-useLibraryCodeForTypes = true
-
-# Overly strict settings with false positives
-reportMissingSuperCall = "none"
-reportImplicitStringConcatenation = "none"
-
-# Already flagged by mypy
-reportMissingTypeStubs = "none"
-
-# Strict settings we might want to work towards enabling at some point
-reportUnknownParameterType = false
-reportMissingParameterType = false
-reportUnknownMemberType = false
-reportUnknownArgumentType = false


### PR DESCRIPTION
This PR fixes a few issues flagged by pyright, ~~and adds a `tool.pyright` section to `pyproject.toml` to improve the experience of working on the plugin inside VSCode~~.

(I don't personally feel the need to run pyright in CI, since none of the issues uncovered here are particularly dire.)