### PR TITLE
Use --extend-ignore instead of --ignore

### DIFF
--- a/tests/del.pyi
+++ b/tests/del.pyi
@@ -1,4 +1,4 @@
-# flags: --ignore=Y037
+# flags: --extend-ignore=Y037
 from typing import TypeAlias, Union
 
 ManyStr: TypeAlias = list[EitherStr]

--- a/tests/forward_refs.pyi
+++ b/tests/forward_refs.pyi
@@ -1,4 +1,4 @@
-# flags: --ignore=Y037
+# flags: --extend-ignore=Y037
 from typing import Optional, TypeAlias, Union
 
 MaybeCStr: TypeAlias = Optional[CStr]

--- a/tests/forward_refs_annassign.pyi
+++ b/tests/forward_refs_annassign.pyi
@@ -1,4 +1,4 @@
-# flags: --ignore=Y037
+# flags: --extend-ignore=Y037
 from typing import Optional, TypeAlias, Union
 
 MaybeCStr: TypeAlias = Optional[CStr]

--- a/tests/vanilla_flake8_not_clean_forward_refs.pyi
+++ b/tests/vanilla_flake8_not_clean_forward_refs.pyi
@@ -1,4 +1,4 @@
-# flags: --no-pyi-aware-file-checker --ignore=Y037
+# flags: --no-pyi-aware-file-checker --extend-ignore=Y037
 from typing import TypeAlias, Union
 
 ManyStr: TypeAlias = list[EitherStr]  # F821 undefined name 'EitherStr'


### PR DESCRIPTION
Came up in [#364](https://github.com/PyCQA/flake8-pyi/pull/364#issuecomment-1507207697)

Plain `--ignore` resets the list of ignores which means that the config file is not taken into account.