### PR TITLE
Simplify parsing of command-line options

### DIFF
--- a/pyi.py
+++ b/pyi.py
@@ -1978,8 +1978,8 @@ class PyiTreeChecker:
             tree = LegacyNormalizer().visit(self.tree)
             yield from PyiVisitor(filename=path).run(tree)
 
-    @classmethod
-    def add_options(cls, parser: OptionManager) -> None:
+    @staticmethod
+    def add_options(parser: OptionManager) -> None:
         """This is brittle, there's multiple levels of caching of defaults."""
         if isinstance(parser.parser, argparse.ArgumentParser):
             parser.parser.set_defaults(filename="*.py,*.pyi")
@@ -2001,11 +2001,8 @@ class PyiTreeChecker:
                 help="don't patch flake8 with .pyi-aware file checker",
             )
 
-    @classmethod
-    def parse_options(
-        cls, optmanager: OptionManager, options: argparse.Namespace, extra_args
-    ) -> None:
-        """This is also brittle, only checked with flake8 3.2.1 and master."""
+    @staticmethod
+    def parse_options(options: argparse.Namespace) -> None:
         if not options.no_pyi_aware_file_checker:
             checker.FileChecker = PyiAwareFileChecker
 


### PR DESCRIPTION
According to [the flake8 docs on writing a plugin](https://flake8.pycqa.org/en/latest/plugin-development/plugin-parameters.html#accessing-parsed-options), the `parse_options` method can have either of the two following signatures:

```py
def parse_options(option_manager, options, args):
    pass
# or
def parse_options(options):
    pass
```

We don't use the `option_manager` or `args` parameters, so let's get rid of them and go with the simpler signature. The "we might be doing bad things here" docstring can also go, since this is the officially recommended way of doing things, so it shouldn't be too brittle :)

The `add_options` method can also be simplified: we don't use the `cls` argument, so we can make it a static method rather than a class method. This is [what flake8-bugbear does](https://github.com/PyCQA/flake8-bugbear/blob/8c0e7eb04217494d48d0ab093bf5b31db0921989/bugbear.py#L126-L136).