### PR TITLE
Simplify `PyiVisitor.__init__`

### DIFF
--- a/pyi.py
+++ b/pyi.py
@@ -849,8 +849,8 @@ class NestingCounter:
 
 
 class PyiVisitor(ast.NodeVisitor):
-    def __init__(self, filename: Path | None = None) -> None:
-        self.filename = Path("(none)") if filename is None else filename
+    def __init__(self, filename: str) -> None:
+        self.filename = filename
         self.errors: list[Error] = []
         # Mapping of all private TypeVars/ParamSpecs/TypeVarTuples
         # to the nodes where they're defined
@@ -1970,11 +1970,10 @@ class PyiTreeChecker:
     def run(self) -> Iterable[Error]:
         assert self.lines is not None
         assert self.tree is not None
-        path = Path(self.filename)
-        if path.suffix == ".pyi":
+        if Path(self.filename).suffix == ".pyi":
             yield from _check_for_type_comments(self.lines)
             tree = LegacyNormalizer().visit(self.tree)
-            yield from PyiVisitor(filename=path).run(tree)
+            yield from PyiVisitor(filename=self.filename).run(tree)
 
     @staticmethod
     def add_options(parser: OptionManager) -> None:

--- a/pyi.py
+++ b/pyi.py
@@ -1970,7 +1970,7 @@ class PyiTreeChecker:
     def run(self) -> Iterable[Error]:
         assert self.lines is not None
         assert self.tree is not None
-        if Path(self.filename).suffix == ".pyi":
+        if self.filename.endswith(".pyi"):
             yield from _check_for_type_comments(self.lines)
             tree = LegacyNormalizer().visit(self.tree)
             yield from PyiVisitor(filename=self.filename).run(tree)

--- a/pyi.py
+++ b/pyi.py
@@ -15,7 +15,6 @@ from dataclasses import dataclass
 from functools import partial
 from itertools import chain, zip_longest
 from keyword import iskeyword
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, NamedTuple, Union
 
 from flake8 import checker  # type: ignore[import]


### PR DESCRIPTION
We never initialize `PyiVisitor` instances with a `None` value for the `filename` parameter, so we can just say that it's never `None`, and avoid the ternary condition in `PyiVisitor.__init__`. In fact, we only use the `filename` attribute in `PyiVisitor.__repr__`, and a string will be more readable in the repr than a `Path` object -- so let's just say that it has to be a string rather than a `Path`.