### PR TITLE
Simplify `PyiTreeChecker`

### DIFF
--- a/pyi.py
+++ b/pyi.py
@@ -1961,14 +1961,11 @@ class PyiTreeChecker:
     name: ClassVar[str] = "flake8-pyi"
     version: ClassVar[str] = __version__
 
-    tree: ast.Module | None = None
-    lines: list[str] | None = None
+    tree: ast.Module
+    lines: list[str]
     filename: str = "(none)"
-    options: argparse.Namespace | None = None
 
     def run(self) -> Iterable[Error]:
-        assert self.lines is not None
-        assert self.tree is not None
         if self.filename.endswith(".pyi"):
             yield from _check_for_type_comments(self.lines)
             tree = LegacyNormalizer().visit(self.tree)


### PR DESCRIPTION
We don't use the `options` attribute at all, so we can stop asking flake8 to provide it to us.

Also, it seems like we can rely on flake8 to pass us values for the `tree` and `lines` parameters if we've asked for them, so I don't think there's any need to have the `| None` defaults here. I wondered if these default values might be needed for reading from stdin, but that doesn't seem to be the case (I tried running `flake8 -` and `flake8 --stdin-display-name foo.pyi -` with this change, and both worked fine).

For comparison, `flake8-bugbear` _does_ provide default values for these attributes: https://github.com/PyCQA/flake8-bugbear/blob/8c0e7eb04217494d48d0ab093bf5b31db0921989/bugbear.py#L40-L45

But other plugins, such as flake8-pie, flake8-simplify and flake8-comprehensions, don't:
- https://github.com/sbdchd/flake8-pie/blob/5281898ad207279eb300cf39e09d8cd428aea0b6/flake8_pie/__init__.py#L186-L190
- https://github.com/MartinThoma/flake8-simplify/blob/8c43a67c65fd0b16a1b50fe3bf360b161fbb4b37/flake8_simplify/__init__.py#L151-L152
- https://github.com/adamchainz/flake8-comprehensions/blob/b5a6a7bb34b8432bdfa663d35d76ef4f3741e125/src/flake8_comprehensions/__init__.py#L24-L25

