### PR TITLE
Document and test improvements to F822

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
     are still allowed.)
 
     Contributed by [tomasr8](https://github.com/tomasr8).
-  * when flake8-pyi is installed, pyflakes's F822 check now produces many fewer false
+  * When flake8-pyi is installed, pyflakes's F822 check now produces many fewer false
     positives when flake8 is run on `.pyi` files. It now understands that `x: int` in a
     stub file is sufficient for `x` to be considered "bound", and that `"x"` can
     therefore be included in `__all__`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,19 @@
 
 ## Unreleased
 
-* The way in which flake8-pyi modifies pyflakes runs has been improved. When
-  flake8-pyi is installed, pyflakes will now complain about forward references
-  in default values for function and method parameters (the same as pyflakes
-  does when it checks `.py` files). Unlike in `.py` files, forward references
-  in default values are legal in stub files. However, they are never necessary,
-  and are considered bad style. (Forward references for parameter *annotations*
-  are still allowed.)
+* The way in which flake8-pyi modifies pyflakes runs has been improved:
+  * When flake8-pyi is installed, pyflakes will now complain about forward references
+    in default values for function and method parameters (the same as pyflakes
+    does when it checks `.py` files). Unlike in `.py` files, forward references
+    in default values are legal in stub files. However, they are never necessary,
+    and are considered bad style. (Forward references for parameter *annotations*
+    are still allowed.)
 
-  Contributed by [tomasr8](https://github.com/tomasr8).
+    Contributed by [tomasr8](https://github.com/tomasr8).
+  * when flake8-pyi is installed, pyflakes's F822 check now produces many fewer false
+    positives when flake8 is run on `.pyi` files. It now understands that `x: int` in a
+    stub file is sufficient for `x` to be considered "bound", and that `"x"` can
+    therefore be included in `__all__`.
 
 ## 23.5.0
 

--- a/tests/F822.pyi
+++ b/tests/F822.pyi
@@ -1,0 +1,11 @@
+# This checks that pyflakes emits F822 errors where appropriate,
+# but doesn't emit false positives when checking stub files.
+# flake8-pyi's monkeypatching of pyflakes impacts the way this check works.
+
+__all__ = ["a", "b", "c", "Klass", "d", "e"]  # F822 undefined name 'e' in __all__
+
+a: int
+b: int = 42
+c: int = ...
+class Klass: ...
+def d(): ...


### PR DESCRIPTION
#364 means that pyflakes now doesn't emit nearly the same number of F822 false positives on stub files as it used too. However, the fix was made 'by accident', so we didn't document the change or add tests.