### PR TITLE
Bump some test dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,12 +62,12 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "black==23.3.0",                          # Must match .pre-commit-config.yaml
-    "flake8-bugbear==23.5.9; python_version >= '3.8'",
+    "flake8-bugbear==23.6.5; python_version >= '3.8'",
     "flake8-noqa==1.3.1",
     "isort==5.12.0; python_version >= '3.8'", # Must match .pre-commit-config.yaml
     "mypy==1.3.0",
     "pre-commit-hooks==4.4.0",                # Must match .pre-commit-config.yaml
-    "pytest==7.3.1",
+    "pytest==7.3.2",
     "types-pyflakes<4",
 ]
 


### PR DESCRIPTION
The pytest bump means we don't get so many deprecation warnings in CI on Python 3.12