### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -19,7 +19,7 @@
 #
 # flake8-bugbear rules that cause too many false positives:
 #       B905 "`zip()` without an explicit `strict=True` parameter --
-#           the `strict` parameter was introduced in Python 3.10; we support Python 3.7
+#           the `strict` parameter was introduced in Python 3.10; we support Python 3.8
 #       B907 "Use !r inside f-strings instead of manual quotes" --
 #           produces false positives if you're surrounding things with double quotes
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -29,7 +29,7 @@ jobs:
     timeout-minutes: 5
     strategy:
       matrix:
-        python-version: ["3.7", "3.11"]
+        python-version: ["3.8", "3.11"]
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
@@ -63,7 +63,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
       fail-fast: false
     steps:
       - uses: actions/checkout@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     rev: 23.3.0 # must match pyproject.toml
     hooks:
       - id: black
-        language_version: python3.7
+        language_version: python3.8
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0 # must match pyproject.toml
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ Bugfixes:
   multiple definitions in the same file (e.g. across two branches of an `if
   sys.version_info >= (3, 10)` check). This bug has now been fixed.
 
+Other changes:
+* flake8-pyi no longer supports being run on Python 3.7.
+
 ## 23.5.0
 
 * flake8-pyi no longer supports being run with flake8 <5.0.4.

--- a/pyi.py
+++ b/pyi.py
@@ -510,7 +510,9 @@ def _has_bad_hardcoded_returns(
     ):
         return False
 
-    if not method.args.posonlyargs and not method.args.args:  # weird, but theoretically possible
+    if (
+        not method.args.posonlyargs and not method.args.args
+    ):  # weird, but theoretically possible
         return False
 
     method_name, returns = method.name, method.returns
@@ -1782,10 +1784,7 @@ class PyiVisitor(ast.NodeVisitor):
         non_kw_only_args[0].annotation = None
         new_syntax = _unparse_func_node(cleaned_method)
         new_syntax = re.sub(rf"\b{typevar_name}\b", "Self", new_syntax)
-        self.error(
-            node,
-            Y019.format(typevar_name=typevar_name, new_syntax=new_syntax),
-        )
+        self.error(node, Y019.format(typevar_name=typevar_name, new_syntax=new_syntax))
 
     def _check_instance_method_for_bad_typevars(
         self,

--- a/pyi.py
+++ b/pyi.py
@@ -510,9 +510,8 @@ def _has_bad_hardcoded_returns(
     ):
         return False
 
-    if (
-        not method.args.posonlyargs and not method.args.args
-    ):  # weird, but theoretically possible
+    # weird, but theoretically possible
+    if not method.args.posonlyargs and not method.args.args:
         return False
 
     method_name, returns = method.name, method.returns

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ maintainers = [
 description = "A plugin for flake8 to enable linting .pyi stub files."
 license = { text = "MIT" }
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 keywords = [
     "flake8",
     "pyi",
@@ -38,7 +38,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -61,12 +60,12 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "black==23.3.0",                          # Must match .pre-commit-config.yaml
-    "flake8-bugbear==23.6.5; python_version >= '3.8'",
+    "black==23.3.0",            # Must match .pre-commit-config.yaml
+    "flake8-bugbear==23.6.5",
     "flake8-noqa==1.3.1",
-    "isort==5.12.0; python_version >= '3.8'", # Must match .pre-commit-config.yaml
+    "isort==5.12.0",            # Must match .pre-commit-config.yaml
     "mypy==1.3.0",
-    "pre-commit-hooks==4.4.0",                # Must match .pre-commit-config.yaml
+    "pre-commit-hooks==4.4.0",  # Must match .pre-commit-config.yaml
     "pytest==7.3.2",
     "types-pyflakes<4",
 ]
@@ -84,7 +83,7 @@ skip = ["tests/imports.pyi"]
 skip_gitignore = true
 
 [tool.black]
-target-version = ['py37']
+target-version = ['py38']
 skip-magic-trailing-comma = true
 force-exclude = ".*\\.pyi"
 

--- a/tests/defaults.pyi
+++ b/tests/defaults.pyi
@@ -74,3 +74,10 @@ def f38(x: bytes = b"a_very_long_byte_stringgggggggggggggggggggggggggggggggggggg
 
 foo: str = "a_very_long_stringgggggggggggggggggggggggggggggggggggggggggggggg"  # Y053 String and bytes literals >50 characters long are not permitted
 bar: bytes = b"a_very_long_byte_stringggggggggggggggggggggggggggggggggggggg"  # Y053 String and bytes literals >50 characters long are not permitted
+
+# Tests for PEP-570 syntax
+def f39(x: "int", /) -> None: ...  # Y020 Quoted annotations should never be used in stubs
+def f40(x: int, /) -> None: ...
+def f41(x: int, /, y: "int") -> None: ...  # Y020 Quoted annotations should never be used in stubs
+def f42(x: str = "y", /) -> None: ...
+def f43(x: str = os.pathsep, /) -> None: ...  # Y011 Only simple default values allowed for typed arguments

--- a/tests/defaults_py38.pyi
+++ b/tests/defaults_py38.pyi
@@ -1,7 +1,0 @@
-import os
-
-def f(x: "int", /) -> None: ...  # Y020 Quoted annotations should never be used in stubs
-def f1(x: int, /) -> None: ...
-def f2(x: int, /, y: "int") -> None: ...  # Y020 Quoted annotations should never be used in stubs
-def f3(x: str = "y", /) -> None: ...
-def f4(x: str = os.pathsep, /) -> None: ...  # Y011 Only simple default values allowed for typed arguments

--- a/tests/quotes.pyi
+++ b/tests/quotes.pyi
@@ -56,14 +56,7 @@ class DocstringAndPass:
     """Docstring"""  # Y021 Docstrings should not be included in stubs
     pass  # Y012 Class body must not contain "pass"
 
-# These two shouldn't trigger Y020 -- empty strings can't be "quoted annotations"
+# These three shouldn't trigger Y020 -- empty strings can't be "quoted annotations"
 k = ""  # Y052 Need type annotation for "k"
 el = r""  # Y052 Need type annotation for "el"
-
-# The following should also pass,
-# But we can't test for it in CI, because the error message is *very* slightly different on 3.7
-#
-# On 3.7:
-# m = u""  # Y015 Bad default value. Use "m = ..." instead of "m = ''"
-# On 3.8+:
-# m = u""  # Y015 Bad default value. Use "m = ..." instead of "m = u''"
+m = u""  # Y052 Need type annotation for "m"


### PR DESCRIPTION
Part (1) of #392. 3.7 is still a few days away from being officially end-of-life, but we can just hold off cutting a release until it is.

I'll remove our usage of the deprecated AST nodes in a separate PR.