### PR TITLE
Require flake8 v6 or newer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Bugfixes:
 
 Other changes:
 * flake8-pyi no longer supports being run on Python 3.7.
+* flake8-pyi no longer supports being run with flake8 <v6.
 
 ## 23.5.0
 

--- a/pyi.py
+++ b/pyi.py
@@ -4,12 +4,11 @@ from __future__ import annotations
 import argparse
 import ast
 import logging
-import optparse
 import re
 import sys
 from collections import Counter, defaultdict
 from collections.abc import Container, Iterable, Iterator, Sequence
-from contextlib import contextmanager, suppress
+from contextlib import contextmanager
 from copy import deepcopy
 from dataclasses import dataclass
 from functools import partial
@@ -2003,25 +2002,14 @@ class PyiTreeChecker:
     @staticmethod
     def add_options(parser: OptionManager) -> None:
         """This is brittle, there's multiple levels of caching of defaults."""
-        if isinstance(parser.parser, argparse.ArgumentParser):
-            parser.parser.set_defaults(filename="*.py,*.pyi")
-        else:
-            for option in parser.options:
-                if option.long_option_name == "--filename":
-                    option.default = "*.py,*.pyi"
-                    option.option_kwargs["default"] = option.default
-                    option.to_optparse().default = option.default
-                    parser.parser.defaults[option.dest] = option.default
-
-        with suppress(optparse.OptionConflictError):
-            # In tests, sometimes this option gets called twice for some reason.
-            parser.add_option(
-                "--no-pyi-aware-file-checker",
-                default=False,
-                action="store_true",
-                parse_from_config=True,
-                help="don't patch flake8 with .pyi-aware file checker",
-            )
+        parser.parser.set_defaults(filename="*.py,*.pyi")
+        parser.add_option(
+            "--no-pyi-aware-file-checker",
+            default=False,
+            action="store_true",
+            parse_from_config=True,
+            help="don't patch flake8 with .pyi-aware file checker",
+        )
 
     @staticmethod
     def parse_options(options: argparse.Namespace) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ classifiers = [
     "Topic :: Software Development :: Quality Assurance",
 ]
 dependencies = [
-    "flake8 >= 5.0.4, < 7.0.0",
+    "flake8 >= 6.0.0, < 7.0.0",
     "pyflakes >= 2.1.1",
     "ast-decompiler >= 0.7.0, < 1.0; python_version < '3.9'",
 ]


### PR DESCRIPTION
We no longer need to support running with flake8 v5 now that we require Python 3.8+. Flake8 v6 drops support for optparse, which allows us to clean up some code.

Part of #392.