### PR TITLE
Be slightly less invasive in how we monkeypatch pyflakes

### DIFF
--- a/pyi.py
+++ b/pyi.py
@@ -172,12 +172,12 @@ class PyflakesPreProcessor(ast.NodeTransformer):
 
     def visit_ClassDef(self, node: ast.ClassDef) -> ast.ClassDef:
         self.generic_visit(node)
-        node.bases = [
-            # Remove the subscript to prevent F821 errors from being emitted
-            # for (valid) recursive definitions: Foo[Bar] --> Foo
-            base.value if isinstance(base, ast.Subscript) else base
-            for base in node.bases
-        ]
+        for base in node.bases:
+            if isinstance(base, ast.Subscript):
+                # Stringify the subscript to prevent F821 errors from being emitted
+                # for (valid) recursive definitions: Foo[Bar] --> Foo["Bar"]
+                base.slice = ast.Constant(value=unparse(base.slice))
+                ast.fix_missing_locations(base)
         return node
 
 

--- a/pyi.py
+++ b/pyi.py
@@ -176,10 +176,11 @@ class PyflakesPreProcessor(ast.NodeTransformer):
             if isinstance(base, ast.Subscript):
                 # Stringify the subscript to prevent F821 errors from being emitted
                 # for (valid) recursive definitions: Foo[Bar] --> Foo["Bar"]
+                new_slice = ast.Constant(value=unparse(base.slice), kind=None)
                 if sys.version_info >= (3, 9):
-                    base.slice = ast.Constant(value=unparse(base.slice))
+                    base.slice = new_slice
                 else:
-                    base.slice = ast.Index(ast.Constant(value=unparse(base.slice)))
+                    base.slice = ast.Index(value=new_slice, ctx=ast.Load())
                 ast.fix_missing_locations(base)
         return node
 

--- a/pyi.py
+++ b/pyi.py
@@ -176,7 +176,10 @@ class PyflakesPreProcessor(ast.NodeTransformer):
             if isinstance(base, ast.Subscript):
                 # Stringify the subscript to prevent F821 errors from being emitted
                 # for (valid) recursive definitions: Foo[Bar] --> Foo["Bar"]
-                base.slice = ast.Constant(value=unparse(base.slice))
+                if sys.version_info >= (3, 9):
+                    base.slice = ast.Constant(value=unparse(base.slice))
+                else:
+                    base.slice = ast.Index(ast.Constant(value=unparse(base.slice)))
                 ast.fix_missing_locations(base)
         return node
 


### PR DESCRIPTION
Stringifying the slices in `ast.Subscript` bases feels slightly less invasive than removing the slice altogether