### PR TITLE
Fail CI on encountering deprecation warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,3 +102,4 @@ ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 addopts = "--doctest-modules"
+filterwarnings = ["error"]

--- a/tests/test_pyi_files.py
+++ b/tests/test_pyi_files.py
@@ -47,7 +47,7 @@ def test_pyi_file(path: str) -> None:
     # For DeprecationWarnings coming from flake8-pyi itself,
     # print the first occurence of each warning to stderr.
     # This will fail CI the same as `-Werror:::pyi`,
-    # but the test failure report that pyflakes gives is much easier to read
+    # but the test failure report that pytest gives is much easier to read
     # if we use `-Wdefault:::pyi`
     flake8_invocation = [
         sys.executable,

--- a/tests/test_pyi_files.py
+++ b/tests/test_pyi_files.py
@@ -78,7 +78,7 @@ def test_pyi_file(path: str) -> None:
     run_results = [
         # Passing a file on command line
         subprocess.run(
-            [sys.executable, "-Wa", "-m", "flake8", "-j0", *flags, path],
+            [sys.executable, "-Walways", "-m", "flake8", "-j0", *flags, path],
             env={**os.environ, "PYTHONPATH": "."},
             capture_output=True,
             text=True,
@@ -87,7 +87,7 @@ def test_pyi_file(path: str) -> None:
         subprocess.run(
             [
                 sys.executable,
-                "-Wa",
+                "-Walways",
                 "-m",
                 "flake8",
                 "-j0",

--- a/tests/test_pyi_files.py
+++ b/tests/test_pyi_files.py
@@ -8,7 +8,6 @@ from itertools import zip_longest
 
 import pytest
 
-
 IGNORED_DEPRECATION_WARNINGS = [
     # Ignore all DeprecationWarnings that come from pyflakes or flake8-bugbear
     rf"{re.escape(os.path.join('pyflakes', 'checker.py'))}:\d+: DeprecationWarning: ",


### PR DESCRIPTION
Because we run flake8 via a subprocess in our test suite, pytest can't detect any DeprecationWarnings emitted while the plugin is being run. This PR therefore passes `-Wa` to `subprocess.run()`, so that we can capture any DeprecationWarnings emitted in the subprocess, and fail CI if any are emitted.

Some DeprecationWarnings are currently emitted on Python 3.12 by pyflakes and flake8-bugbear, so those need to be ignored in order for this approach to work.

Closes #392