### PR TITLE
Prepare for release 23.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## Unreleased
+## 23.6.0
 
 Features:
 * Support Python 3.12
@@ -33,7 +33,7 @@ Bugfixes:
   sys.version_info >= (3, 10)` check). This bug has now been fixed.
 
 Other changes:
-* flake8-pyi no longer supports being run on Python 3.7.
+* flake8-pyi no longer supports being run on Python 3.7, which is now end-of-life.
 * flake8-pyi no longer supports being run with flake8 <v6.
 
 ## 23.5.0

--- a/pyi.py
+++ b/pyi.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
     # and mypy thinks typing_extensions is part of the stdlib.
     from typing_extensions import Literal, TypeAlias, TypeGuard
 
-__version__ = "23.5.0"
+__version__ = "23.6.0"
 
 LOG = logging.getLogger("flake8.pyi")
 


### PR DESCRIPTION
3.7 is now end-of-life, so I think we're good to go here. (Marking as draft because I'd like it if #407 could get in.)