### PR TITLE
Add a warning for `tuple[int]` annotations

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -24,10 +24,10 @@
 #           produces false positives if you're surrounding things with double quotes
 
 [flake8]
+extend-select = B
 max-line-length = 80
 max-complexity = 12
 noqa-require-code = true
-select = B,C,E,F,W,Y,B9,NQA
 per-file-ignores =
   *.py: B905, B907, B950, E203, E501, W503, W291, W293
   *.pyi: B, E301, E302, E305, E501, E701, E704, W503

--- a/.flake8
+++ b/.flake8
@@ -24,7 +24,7 @@
 #           produces false positives if you're surrounding things with double quotes
 
 [flake8]
-extend-select = B
+extend-select = B9
 max-line-length = 80
 max-complexity = 12
 noqa-require-code = true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## Unreleased
+
+* Introduce Y090, which warns if you have an annotation such as `tuple[int]` or
+  `Tuple[int]`. These mean "a tuple of length 1, in which the sole element is
+  of type `int`". This is sometimes what you want, but more usually you'll want
+  `tuple[int, ...]`, which means "a tuple of arbitrary (possibly 0) length, in
+  which all elements are of type `int`".
+
+  This error code is disabled by default due to the risk of false-positive
+  errors. To enable it, use the `--extend-select=Y090` option.
+
 ## 23.6.0
 
 Features:

--- a/ERRORCODES.md
+++ b/ERRORCODES.md
@@ -61,6 +61,8 @@ The following warnings are currently emitted by default:
 | Y056 | Do not call methods such as `.append()`, `.extend()` or `.remove()` on `__all__`. Different type checkers have varying levels of support for calling these methods on `__all__`. Use `+=` instead, which is known to be supported by all major type checkers.
 | Y057 | Do not use `typing.ByteString` or `collections.abc.ByteString`. These types have unclear semantics, and are deprecated; use  `typing_extensions.Buffer` or a union such as `bytes \| bytearray \| memoryview` instead. See [PEP 688](https://peps.python.org/pep-0688/) for more details.
 
+## Warnings disabled by default
+
 The following error codes are also provided, but are disabled by default due to
 the risk of false-positive errors. To enable these error codes, use
 `--extend-select={code1,code2,...}` on the command line or in your flake8

--- a/ERRORCODES.md
+++ b/ERRORCODES.md
@@ -61,9 +61,14 @@ The following warnings are currently emitted by default:
 | Y056 | Do not call methods such as `.append()`, `.extend()` or `.remove()` on `__all__`. Different type checkers have varying levels of support for calling these methods on `__all__`. Use `+=` instead, which is known to be supported by all major type checkers.
 | Y057 | Do not use `typing.ByteString` or `collections.abc.ByteString`. These types have unclear semantics, and are deprecated; use  `typing_extensions.Buffer` or a union such as `bytes \| bytearray \| memoryview` instead. See [PEP 688](https://peps.python.org/pep-0688/) for more details.
 
-The following error codes are also provided, but are disabled by default due to the risk of false-positive errors. To enable these error codes, use
+The following error codes are also provided, but are disabled by default due to
+the risk of false-positive errors. To enable these error codes, use
 `--extend-select={code1,code2,...}` on the command line or in your flake8
-configuration file:
+configuration file.
+
+Note that `--extend-select` **will not work** if you have
+`--select` specified on the command line or in your configuration file. We
+recommend only using `--extend-select`, never `--select`.
 
 | Code | Description
 |------|------------

--- a/ERRORCODES.md
+++ b/ERRORCODES.md
@@ -1,6 +1,6 @@
 ## List of warnings
 
-The following warnings are currently emitted:
+The following warnings are currently emitted by default:
 
 | Code | Description
 |------|-------------
@@ -60,3 +60,11 @@ The following warnings are currently emitted:
 | Y055 | Unions of the form `type[X] \| type[Y]` can be simplified to `type[X \| Y]`. Similarly, `Union[type[X], type[Y]]` can be simplified to `type[Union[X, Y]]`.
 | Y056 | Do not call methods such as `.append()`, `.extend()` or `.remove()` on `__all__`. Different type checkers have varying levels of support for calling these methods on `__all__`. Use `+=` instead, which is known to be supported by all major type checkers.
 | Y057 | Do not use `typing.ByteString` or `collections.abc.ByteString`. These types have unclear semantics, and are deprecated; use  `typing_extensions.Buffer` or a union such as `bytes \| bytearray \| memoryview` instead. See [PEP 688](https://peps.python.org/pep-0688/) for more details.
+
+The following error codes are also provided, but are disabled by default due to the risk of false-positive errors. To enable these error codes, use
+`--extend-select={code1,code2,...}` on the command line or in your flake8
+configuration file:
+
+| Code | Description
+|------|------------
+| Y090 | `tuple[int]` means "a tuple of length 1, in which the sole element is of type `int`". Consider using`tuple[int, ...]` instead, which means "a tuple of arbitrary (possibly 0) length, in which all elements are of type `int`".

--- a/ERRORCODES.md
+++ b/ERRORCODES.md
@@ -72,4 +72,4 @@ recommend only using `--extend-select`, never `--select`.
 
 | Code | Description
 |------|------------
-| Y090 | `tuple[int]` means "a tuple of length 1, in which the sole element is of type `int`". Consider using`tuple[int, ...]` instead, which means "a tuple of arbitrary (possibly 0) length, in which all elements are of type `int`".
+| Y090 | `tuple[int]` means "a tuple of length 1, in which the sole element is of type `int`". Consider using `tuple[int, ...]` instead, which means "a tuple of arbitrary (possibly 0) length, in which all elements are of type `int`".

--- a/pyi.py
+++ b/pyi.py
@@ -1359,7 +1359,11 @@ class PyiVisitor(ast.NodeVisitor):
         current_code = unparse(node)
         typ = unparse(node.slice)
         copied_node = deepcopy(node)
-        copied_node.slice = ast.Tuple(elts=[copied_node.slice, ast.Constant(...)])
+        new_slice = ast.Tuple(elts=[copied_node.slice, ast.Constant(...)])
+        if sys.version_info >= (3, 9):
+            copied_node.slice = new_slice
+        else:
+            copied_node.slice = ast.Index(new_slice)
         suggestion = unparse(copied_node)
         self.error(node, Y090.format(original=current_code, typ=typ, new=suggestion))
 

--- a/tests/disabled_by_default.pyi
+++ b/tests/disabled_by_default.pyi
@@ -1,7 +1,7 @@
 # This test file checks that disabled-by-default error codes aren't triggered,
 # unless they're explicitly enabled
-from typing import (
-    Tuple,  # Y022 Use "tuple[Foo, Bar]" instead of "typing.Tuple[Foo, Bar]" (PEP 585 syntax)
+from typing import (  # Y022 Use "tuple[Foo, Bar]" instead of "typing.Tuple[Foo, Bar]" (PEP 585 syntax)
+    Tuple,
 )
 
 # These would trigger Y090, but it's disabled by default

--- a/tests/disabled_by_default.pyi
+++ b/tests/disabled_by_default.pyi
@@ -1,0 +1,7 @@
+# This test file checks that disabled-by-default error codes aren't triggered,
+# unless they're explicitly enabled
+from typing import Tuple  # Y022 Use "tuple[Foo, Bar]" instead of "typing.Tuple[Foo, Bar]" (PEP 585 syntax)
+
+# These would trigger Y090, but it's disabled by default
+x: tuple[int]
+y: Tuple[str]

--- a/tests/single_element_tuples.pyi
+++ b/tests/single_element_tuples.pyi
@@ -1,0 +1,8 @@
+# flags: --extend-select=Y090
+import builtins
+import typing
+
+a: tuple[int]  # Y090 "tuple[int]" means "a tuple of length 1, in which the sole element is of type 'int'". Perhaps you meant "tuple[int, ...]"?
+b: typing.Tuple[builtins.str]  # Y022 Use "tuple[Foo, Bar]" instead of "typing.Tuple[Foo, Bar]" (PEP 585 syntax)  # Y090 "typing.Tuple[builtins.str]" means "a tuple of length 1, in which the sole element is of type 'builtins.str'". Perhaps you meant "typing.Tuple[builtins.str, ...]"?
+c: tuple[int, ...]
+d: typing.Tuple[builtins.str, builtins.complex]  # Y022 Use "tuple[Foo, Bar]" instead of "typing.Tuple[Foo, Bar]" (PEP 585 syntax)

--- a/tests/test_pyi_files.py
+++ b/tests/test_pyi_files.py
@@ -35,12 +35,13 @@ def test_pyi_file(path: str) -> None:
             expected_output += f"{path}:{lineno}: {match.group(1)}{message}\n"
 
     bad_flag_msg = (
-        "--ignore flags in test files override the .flake8 config file. "
-        "Use --extend-ignore instead."
-    )
+        "--{flag} flags in test files override the .flake8 config file. "
+        "Use --extend-{flag} instead."
+    ).format
+
     for flag in flags:
         option = flag.split("=")[0]
-        assert option != "--ignore", bad_flag_msg
+        assert option not in {"--ignore", "--select"}, bad_flag_msg(option[2:])
 
     # Silence DeprecationWarnings from our dependencies (pyflakes, flake8-bugbear, etc.)
     #


### PR DESCRIPTION
Fixes #131

The error code is disabled by default, so as to avoid false positives. If this PR is merged, I can work on creating a non-blocking mypy_primer-esque workflow for typeshed (which runs flake8 only on changed files, with `--extend-select=Y090`, and posts a comment showing the new errors) to flag potential issues in PRs.

Here's the output if I run `flake8 --extend-select=Y090 stubs stdlib` with this PR branch from inside my typeshed clone:

<details>

```
stdlib\_ctypes.pyi:102:18: Y090 "tuple[int]" means "a tuple of length 1, in which the sole element is of type 'int'". Perhaps you meant "tuple[int, ...]"?
stdlib\_decimal.pyi:166:47: Y090 "tuple[str]" means "a tuple of length 1, in which the sole element is of type 'str'". Perhaps you meant "tuple[str, ...]"?
stdlib\asyncio\tasks.pyi:76:109: Y090 "tuple[_T1]" means "a tuple of length 1, in which the sole element is of type '_T1'". Perhaps you meant "tuple[_T1, ...]"?
stdlib\asyncio\tasks.pyi:109:91: Y090 "tuple[_T1 | BaseException]" means "a tuple of length 1, in which the sole element is of type '_T1 | BaseException'". Perhaps you meant "tuple[_T1 | BaseException, ...]"?
stdlib\asyncio\tasks.pyi:150:17: Y090 "tuple[_T1]" means "a tuple of length 1, in which the sole element is of type '_T1'". Perhaps you meant "tuple[_T1, ...]"?
stdlib\asyncio\tasks.pyi:192:17: Y090 "tuple[_T1 | BaseException]" means "a tuple of length 1, in which the sole element is of type '_T1 | BaseException'". Perhaps you meant "tuple[_T1 | BaseException, ...]"?
stdlib\builtins.pyi:309:33: Y090 "tuple[int]" means "a tuple of length 1, in which the sole element is of type 'int'". Perhaps you meant "tuple[int, ...]"?
stdlib\builtins.pyi:362:33: Y090 "tuple[float]" means "a tuple of length 1, in which the sole element is of type 'float'". Perhaps you meant "tuple[float, ...]"?
stdlib\builtins.pyi:612:33: Y090 "tuple[str]" means "a tuple of length 1, in which the sole element is of type 'str'". Perhaps you meant "tuple[str, ...]"?
stdlib\builtins.pyi:714:33: Y090 "tuple[bytes]" means "a tuple of length 1, in which the sole element is of type 'bytes'". Perhaps you meant "tuple[bytes, ...]"?
stdlib\builtins.pyi:930:33: Y090 "tuple[int]" means "a tuple of length 1, in which the sole element is of type 'int'". Perhaps you meant "tuple[int, ...]"?
stdlib\builtins.pyi:1794:80: Y090 "tuple[_T1]" means "a tuple of length 1, in which the sole element is of type '_T1'". Perhaps you meant "tuple[_T1, ...]"?
stdlib\builtins.pyi:1836:57: Y090 "tuple[_T1]" means "a tuple of length 1, in which the sole element is of type '_T1'". Perhaps you meant "tuple[_T1, ...]"?
stdlib\collections\__init__.pyi:144:33: Y090 "tuple[str]" means "a tuple of length 1, in which the sole element is of type 'str'". Perhaps you meant "tuple[str, ...]"?
stdlib\distutils\ccompiler.pyi:5:21: Y090 "tuple[str]" means "a tuple of length 1, in which the sole element is of type 'str'". Perhaps you meant "tuple[str, ...]"?
stdlib\functools.pyi:88:18: Y090 "tuple[Literal['__dict__']]" means "a tuple of length 1, in which the sole element is of type "Literal['__dict__']"". Perhaps you meant "tuple[Literal['__dict__'], ...]"?
stdlib\ipaddress.pyi:18:48: Y090 "tuple[_RawIPAddress]" means "a tuple of length 1, in which the sole element is of type '_RawIPAddress'". Perhaps you meant "tuple[_RawIPAddress, ...]"?
stdlib\ipaddress.pyi:21:48: Y090 "tuple[_RawIPAddress]" means "a tuple of length 1, in which the sole element is of type '_RawIPAddress'". Perhaps you meant "tuple[_RawIPAddress, ...]"?
stdlib\itertools.pyi:118:89: Y090 "tuple[_T1]" means "a tuple of length 1, in which the sole element is of type '_T1'". Perhaps you meant "tuple[_T1, ...]"?
stdlib\itertools.pyi:197:57: Y090 "tuple[_T1]" means "a tuple of length 1, in which the sole element is of type '_T1'". Perhaps you meant "tuple[_T1, ...]"?
stdlib\logging\config.pyi:128:43: Y090 "tuple[Any]" means "a tuple of length 1, in which the sole element is of type 'Any'". Perhaps you meant "tuple[Any, ...]"?
stdlib\logging\config.pyi:128:58: Y090 "tuple[Any]" means "a tuple of length 1, in which the sole element is of type 'Any'". Perhaps you meant "tuple[Any, ...]"?
stdlib\logging\handlers.pyi:206:25: Y090 "tuple[str]" means "a tuple of length 1, in which the sole element is of type 'str'". Perhaps you meant "tuple[str, ...]"?
stdlib\logging\handlers.pyi:215:29: Y090 "tuple[str]" means "a tuple of length 1, in which the sole element is of type 'str'". Perhaps you meant "tuple[str, ...]"?
stdlib\os\__init__.pyi:960:39: Y090 "tuple[int]" means "a tuple of length 1, in which the sole element is of type 'int'". Perhaps you meant "tuple[int, ...]"?
stdlib\plistlib.pyi:104:51: Y090 "tuple[int]" means "a tuple of length 1, in which the sole element is of type 'int'". Perhaps you meant "tuple[int, ...]"?
stdlib\smtplib.pyi:58:11: Y090 "tuple[_SendErrs]" means "a tuple of length 1, in which the sole element is of type '_SendErrs'". Perhaps you meant "tuple[_SendErrs, ...]"?
stdlib\tkinter\__init__.pyi:179:28: Y090 "tuple[str]" means "a tuple of length 1, in which the sole element is of type 'str'". Perhaps you meant "tuple[str, ...]"?
stdlib\tkinter\ttk.pyi:43:7: Y090 "tuple[tkinter._ScreenUnits]" means "a tuple of length 1, in which the sole element is of type 'tkinter._ScreenUnits'". Perhaps you meant "tuple[tkinter._ScreenUnits, ...]"?
stdlib\tkinter\ttk.pyi:1036:79: Y090 "tuple[str]" means "a tuple of length 1, in which the sole element is of type 'str'". Perhaps you meant "tuple[str, ...]"?
stdlib\tkinter\ttk.pyi:1078:60: Y090 "tuple[str]" means "a tuple of length 1, in which the sole element is of type 'str'". Perhaps you meant "tuple[str, ...]"?
stdlib\xml\dom\minicompat.pyi:9:14: Y090 "tuple[type[str]]" means "a tuple of length 1, in which the sole element is of type 'type[str]'". Perhaps you meant "tuple[type[str], ...]"?
stubs\ExifRead\exifread\_types.pyi:8:32: Y090 "tuple[str]" means "a tuple of length 1, in which the sole element is of type 'str'". Perhaps you meant "tuple[str, ...]"?
stubs\Pillow\PIL\Image.pyi:33:11: Y090 "tuple[int]" means "a tuple of length 1, in which the sole element is of type 'int'". Perhaps you meant "tuple[int, ...]"?
stubs\Pillow\PIL\Image.pyi:33:107: Y090 "tuple[float]" means "a tuple of length 1, in which the sole element is of type 'float'". Perhaps you meant "tuple[float, ...]"?
stubs\WebOb\webob\request.pyi:122:14: Y090 "tuple[str]" means "a tuple of length 1, in which the sole element is of type 'str'". Perhaps you meant "tuple[str, ...]"?
stubs\beautifulsoup4\bs4\element.pyi:187:33: Y090 "tuple[str]" means "a tuple of length 1, in which the sole element is of type 'str'". Perhaps you meant "tuple[str, ...]"?
stubs\colorama\colorama\ansitowin32.pyi:29:41: Y090 "tuple[_WinTermCall]" means "a tuple of length 1, in which the sole element is of type '_WinTermCall'". Perhaps you meant "tuple[_WinTermCall, ...]"?
stubs\fpdf2\fpdf\drawing.pyi:54:25: Y090 "tuple[Number]" means "a tuple of length 1, in which the sole element is of type 'Number'". Perhaps you meant "tuple[Number, ...]"?
stubs\keyboard\keyboard\mouse.pyi:74:58: Y090 "tuple[_MouseEventType]" means "a tuple of length 1, in which the sole element is of type '_MouseEventType'". Perhaps you meant "tuple[_MouseEventType, ...]"?
stubs\openpyxl\openpyxl\workbook\workbook.pyi:13:22: Y090 "tuple[type[int]]" means "a tuple of length 1, in which the sole element is of type 'type[int]'". Perhaps you meant "tuple[type[int], ...]"?
stubs\paho-mqtt\paho\mqtt\client.pyi:98:61: Y090 "tuple[int]" means "a tuple of length 1, in which the sole element is of type 'int'". Perhaps you meant "tuple[int, ...]"?
stubs\paramiko\paramiko\ssh_exception.pyi:38:41: Y090 "tuple[Mapping[tuple[str, int] | tuple[str, int, int, int], Exception]]" means "a tuple of length 1, in which the sole element is of type 'Mapping[tuple[str, int] | tuple[str, int, int, int], Exception]'". Perhaps you meant "tuple[Mapping[tuple[str, int] | tuple[str, int, int, int], Exception], ...]"?
stubs\parsimonious\parsimonious\expressions.pyi:25:21: Y090 "tuple[str]" means "a tuple of length 1, in which the sole element is of type 'str'". Perhaps you meant "tuple[str, ...]"?
stubs\pika\pika\compat.pyi:27:19: Y090 "tuple[type[str]]" means "a tuple of length 1, in which the sole element is of type 'type[str]'". Perhaps you meant "tuple[type[str], ...]"?
stubs\pyflakes\pyflakes\messages.pyi:13:19: Y090 "tuple[Any]" means "a tuple of length 1, in which the sole element is of type 'Any'". Perhaps you meant "tuple[Any, ...]"?
stubs\pyflakes\pyflakes\messages.pyi:29:19: Y090 "tuple[Any]" means "a tuple of length 1, in which the sole element is of type 'Any'". Perhaps you meant "tuple[Any, ...]"?
stubs\pyflakes\pyflakes\messages.pyi:37:19: Y090 "tuple[Any]" means "a tuple of length 1, in which the sole element is of type 'Any'". Perhaps you meant "tuple[Any, ...]"?
stubs\pyflakes\pyflakes\messages.pyi:45:19: Y090 "tuple[Any]" means "a tuple of length 1, in which the sole element is of type 'Any'". Perhaps you meant "tuple[Any, ...]"?
stubs\pyflakes\pyflakes\messages.pyi:55:19: Y090 "tuple[Any]" means "a tuple of length 1, in which the sole element is of type 'Any'". Perhaps you meant "tuple[Any, ...]"?
stubs\pyflakes\pyflakes\messages.pyi:59:19: Y090 "tuple[Any]" means "a tuple of length 1, in which the sole element is of type 'Any'". Perhaps you meant "tuple[Any, ...]"?
stubs\pyflakes\pyflakes\messages.pyi:63:19: Y090 "tuple[Any]" means "a tuple of length 1, in which the sole element is of type 'Any'". Perhaps you meant "tuple[Any, ...]"?
stubs\pyflakes\pyflakes\messages.pyi:71:19: Y090 "tuple[Any]" means "a tuple of length 1, in which the sole element is of type 'Any'". Perhaps you meant "tuple[Any, ...]"?
stubs\pyflakes\pyflakes\messages.pyi:75:19: Y090 "tuple[Any]" means "a tuple of length 1, in which the sole element is of type 'Any'". Perhaps you meant "tuple[Any, ...]"?
stubs\pyflakes\pyflakes\messages.pyi:79:19: Y090 "tuple[Any]" means "a tuple of length 1, in which the sole element is of type 'Any'". Perhaps you meant "tuple[Any, ...]"?
stubs\pyflakes\pyflakes\messages.pyi:94:19: Y090 "tuple[Any]" means "a tuple of length 1, in which the sole element is of type 'Any'". Perhaps you meant "tuple[Any, ...]"?
stubs\pyflakes\pyflakes\messages.pyi:103:19: Y090 "tuple[Any]" means "a tuple of length 1, in which the sole element is of type 'Any'". Perhaps you meant "tuple[Any, ...]"?
stubs\pyflakes\pyflakes\messages.pyi:107:19: Y090 "tuple[Any]" means "a tuple of length 1, in which the sole element is of type 'Any'". Perhaps you meant "tuple[Any, ...]"?
stubs\pyflakes\pyflakes\messages.pyi:111:19: Y090 "tuple[Any]" means "a tuple of length 1, in which the sole element is of type 'Any'". Perhaps you meant "tuple[Any, ...]"?
stubs\pyflakes\pyflakes\messages.pyi:117:19: Y090 "tuple[Any]" means "a tuple of length 1, in which the sole element is of type 'Any'". Perhaps you meant "tuple[Any, ...]"?
stubs\pyflakes\pyflakes\messages.pyi:121:19: Y090 "tuple[Any]" means "a tuple of length 1, in which the sole element is of type 'Any'". Perhaps you meant "tuple[Any, ...]"?
stubs\pyflakes\pyflakes\messages.pyi:127:19: Y090 "tuple[Any]" means "a tuple of length 1, in which the sole element is of type 'Any'". Perhaps you meant "tuple[Any, ...]"?
stubs\pyflakes\pyflakes\messages.pyi:135:19: Y090 "tuple[Any]" means "a tuple of length 1, in which the sole element is of type 'Any'". Perhaps you meant "tuple[Any, ...]"?
stubs\pyflakes\pyflakes\messages.pyi:139:19: Y090 "tuple[Any]" means "a tuple of length 1, in which the sole element is of type 'Any'". Perhaps you meant "tuple[Any, ...]"?
stubs\pyinstaller\PyInstaller\lib\modulegraph\modulegraph.pyi:34:28: Y090 "tuple[str]" means "a tuple of length 1, in which the sole element is of type 'str'". Perhaps you meant "tuple[str, ...]"?
stubs\python-xlib\Xlib\protocol\rq.pyi:323:13: Y090 "tuple[Field]" means "a tuple of length 1, in which the sole element is of type 'Field'". Perhaps you meant "tuple[Field, ...]"?
stubs\pywin32\_win32typing.pyi:199:44: Y090 "tuple[dict[str, int | dict[str, int | PySID]]]" means "a tuple of length 1, in which the sole element is of type 'dict[str, int | dict[str, int | PySID]]'". Perhaps you meant "tuple[dict[str, int | dict[str, int | PySID]], ...]"?
stubs\pywin32\win32\win32help.pyi:11:53: Y090 "tuple[int]" means "a tuple of length 1, in which the sole element is of type 'int'". Perhaps you meant "tuple[int, ...]"?
stubs\pywin32\win32com\server\policy.pyi:26:82: Y090 "tuple[Incomplete]" means "a tuple of length 1, in which the sole element is of type 'Incomplete'". Perhaps you meant "tuple[Incomplete, ...]"?
stubs\pywin32\win32com\server\policy.pyi:28:82: Y090 "tuple[Incomplete]" means "a tuple of length 1, in which the sole element is of type 'Incomplete'". Perhaps you meant "tuple[Incomplete, ...]"?
stubs\pywin32\win32com\server\policy.pyi:32:82: Y090 "tuple[Incomplete]" means "a tuple of length 1, in which the sole element is of type 'Incomplete'". Perhaps you meant "tuple[Incomplete, ...]"?
stubs\pywin32\win32com\server\policy.pyi:38:82: Y090 "tuple[Incomplete]" means "a tuple of length 1, in which the sole element is of type 'Incomplete'". Perhaps you meant "tuple[Incomplete, ...]"?
stubs\redis\redis\credentials.pyi:5:34: Y090 "tuple[str]" means "a tuple of length 1, in which the sole element is of type 'str'". Perhaps you meant "tuple[str, ...]"?
stubs\redis\redis\credentials.pyi:11:34: Y090 "tuple[str]" means "a tuple of length 1, in which the sole element is of type 'str'". Perhaps you meant "tuple[str, ...]"?
stubs\redis\redis\exceptions.pyi:25:11: Y090 "tuple[str]" means "a tuple of length 1, in which the sole element is of type 'str'". Perhaps you meant "tuple[str, ...]"?
stubs\redis\redis\exceptions.pyi:30:11: Y090 "tuple[str]" means "a tuple of length 1, in which the sole element is of type 'str'". Perhaps you meant "tuple[str, ...]"?
stubs\regex\regex\regex.pyi:641:30: Y090 "tuple[list[AnyStr]]" means "a tuple of length 1, in which the sole element is of type 'list[AnyStr]'". Perhaps you meant "tuple[list[AnyStr], ...]"?
stubs\regex\regex\regex.pyi:642:27: Y090 "tuple[list[tuple[int, int]]]" means "a tuple of length 1, in which the sole element is of type 'list[tuple[int, int]]'". Perhaps you meant "tuple[list[tuple[int, int]], ...]"?
stubs\setuptools\setuptools\_distutils\ccompiler.pyi:5:21: Y090 "tuple[str]" means "a tuple of length 1, in which the sole element is of type 'str'". Perhaps you meant "tuple[str, ...]"?
stubs\six\six\__init__.pyi:34:15: Y090 "tuple[type[str]]" means "a tuple of length 1, in which the sole element is of type 'type[str]'". Perhaps you meant "tuple[type[str], ...]"?
stubs\six\six\__init__.pyi:35:16: Y090 "tuple[type[int]]" means "a tuple of length 1, in which the sole element is of type 'type[int]'". Perhaps you meant "tuple[type[int], ...]"?
stubs\six\six\__init__.pyi:36:14: Y090 "tuple[type[type]]" means "a tuple of length 1, in which the sole element is of type 'type[type]'". Perhaps you meant "tuple[type[type], ...]"?
stubs\tqdm\tqdm\asyncio.pyi:47:55: Y090 "tuple[bool | None]" means "a tuple of length 1, in which the sole element is of type 'bool | None'". Perhaps you meant "tuple[bool | None, ...]"?
stubs\tqdm\tqdm\asyncio.pyi:79:55: Y090 "tuple[bool | None]" means "a tuple of length 1, in which the sole element is of type 'bool | None'". Perhaps you meant "tuple[bool | None, ...]"?
stubs\tqdm\tqdm\asyncio.pyi:108:55: Y090 "tuple[bool | None]" means "a tuple of length 1, in which the sole element is of type 'bool | None'". Perhaps you meant "tuple[bool | None, ...]"?
stubs\tqdm\tqdm\asyncio.pyi:139:55: Y090 "tuple[bool | None]" means "a tuple of length 1, in which the sole element is of type 'bool | None'". Perhaps you meant "tuple[bool | None, ...]"?
stubs\tqdm\tqdm\asyncio.pyi:173:51: Y090 "tuple[bool | None]" means "a tuple of length 1, in which the sole element is of type 'bool | None'". Perhaps you meant "tuple[bool | None, ...]"?
stubs\tqdm\tqdm\asyncio.pyi:202:51: Y090 "tuple[bool | None]" means "a tuple of length 1, in which the sole element is of type 'bool | None'". Perhaps you meant "tuple[bool | None, ...]"?
stubs\tqdm\tqdm\contrib\discord.pyi:44:55: Y090 "tuple[bool | None]" means "a tuple of length 1, in which the sole element is of type 'bool | None'". Perhaps you meant "tuple[bool | None, ...]"?
stubs\tqdm\tqdm\contrib\discord.pyi:75:55: Y090 "tuple[bool | None]" means "a tuple of length 1, in which the sole element is of type 'bool | None'". Perhaps you meant "tuple[bool | None, ...]"?
stubs\tqdm\tqdm\contrib\slack.pyi:45:55: Y090 "tuple[bool | None]" means "a tuple of length 1, in which the sole element is of type 'bool | None'". Perhaps you meant "tuple[bool | None, ...]"?
stubs\tqdm\tqdm\contrib\slack.pyi:78:55: Y090 "tuple[bool | None]" means "a tuple of length 1, in which the sole element is of type 'bool | None'". Perhaps you meant "tuple[bool | None, ...]"?
stubs\tqdm\tqdm\contrib\telegram.pyi:50:55: Y090 "tuple[bool | None]" means "a tuple of length 1, in which the sole element is of type 'bool | None'". Perhaps you meant "tuple[bool | None, ...]"?
stubs\tqdm\tqdm\contrib\telegram.pyi:83:55: Y090 "tuple[bool | None]" means "a tuple of length 1, in which the sole element is of type 'bool | None'". Perhaps you meant "tuple[bool | None, ...]"?
stubs\tqdm\tqdm\gui.pyi:50:55: Y090 "tuple[bool | None]" means "a tuple of length 1, in which the sole element is of type 'bool | None'". Perhaps you meant "tuple[bool | None, ...]"?
stubs\tqdm\tqdm\gui.pyi:81:55: Y090 "tuple[bool | None]" means "a tuple of length 1, in which the sole element is of type 'bool | None'". Perhaps you meant "tuple[bool | None, ...]"?
stubs\tqdm\tqdm\notebook.pyi:56:55: Y090 "tuple[bool | None]" means "a tuple of length 1, in which the sole element is of type 'bool | None'". Perhaps you meant "tuple[bool | None, ...]"?
stubs\tqdm\tqdm\notebook.pyi:87:55: Y090 "tuple[bool | None]" means "a tuple of length 1, in which the sole element is of type 'bool | None'". Perhaps you meant "tuple[bool | None, ...]"?
stubs\tqdm\tqdm\rich.pyi:65:55: Y090 "tuple[bool | None]" means "a tuple of length 1, in which the sole element is of type 'bool | None'". Perhaps you meant "tuple[bool | None, ...]"?
stubs\tqdm\tqdm\rich.pyi:96:55: Y090 "tuple[bool | None]" means "a tuple of length 1, in which the sole element is of type 'bool | None'". Perhaps you meant "tuple[bool | None, ...]"?
stubs\tqdm\tqdm\std.pyi:87:55: Y090 "tuple[bool | None]" means "a tuple of length 1, in which the sole element is of type 'bool | None'". Perhaps you meant "tuple[bool | None, ...]"?
stubs\tqdm\tqdm\std.pyi:118:55: Y090 "tuple[bool | None]" means "a tuple of length 1, in which the sole element is of type 'bool | None'". Perhaps you meant "tuple[bool | None, ...]"?
stubs\tqdm\tqdm\std.pyi:160:55: Y090 "tuple[bool | None]" means "a tuple of length 1, in which the sole element is of type 'bool | None'". Perhaps you meant "tuple[bool | None, ...]"?
stubs\tqdm\tqdm\std.pyi:213:83: Y090 "tuple[bool | None]" means "a tuple of length 1, in which the sole element is of type 'bool | None'". Perhaps you meant "tuple[bool | None, ...]"?
stubs\tqdm\tqdm\std.pyi:256:51: Y090 "tuple[bool | None]" means "a tuple of length 1, in which the sole element is of type 'bool | None'". Perhaps you meant "tuple[bool | None, ...]"?
stubs\tqdm\tqdm\std.pyi:285:51: Y090 "tuple[bool | None]" means "a tuple of length 1, in which the sole element is of type 'bool | None'". Perhaps you meant "tuple[bool | None, ...]"?
stubs\tqdm\tqdm\tk.pyi:36:55: Y090 "tuple[bool | None]" means "a tuple of length 1, in which the sole element is of type 'bool | None'". Perhaps you meant "tuple[bool | None, ...]"?
stubs\tqdm\tqdm\tk.pyi:70:55: Y090 "tuple[bool | None]" means "a tuple of length 1, in which the sole element is of type 'bool | None'". Perhaps you meant "tuple[bool | None, ...]"?
stubs\waitress\waitress\compat.pyi:8:15: Y090 "tuple[str]" means "a tuple of length 1, in which the sole element is of type 'str'". Perhaps you meant "tuple[str, ...]"?
stubs\waitress\waitress\compat.pyi:9:16: Y090 "tuple[int]" means "a tuple of length 1, in which the sole element is of type 'int'". Perhaps you meant "tuple[int, ...]"?
stubs\waitress\waitress\compat.pyi:10:14: Y090 "tuple[type]" means "a tuple of length 1, in which the sole element is of type 'type'". Perhaps you meant "tuple[type, ...]"?
```

</details>