### PR TITLE
Switch to PyPI trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,6 +12,9 @@ jobs:
   build-n-publish:
     name: Build and publish Python distributions to PyPI
     runs-on: ubuntu-20.04
+    permissions:
+      # needed for PyPI trusted publishing
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python 3.10
@@ -35,5 +38,3 @@ jobs:
       - name: Publish distribution to PyPI
         if: startsWith(github.ref, 'refs/tags')
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0  # must match pyproject.toml
+    rev: v4.5.0  # must match pyproject.toml
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer


### PR DESCRIPTION
Doing this means we can remove the long-lived `PYPI_API_TOKEN` from this repo, which improves security. See https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/ for more details.

@JelleZijlstra let me know once you've enabled this on PyPI! (We can't merge this until that's done.)

N.B. I'm also bumping `pre-commit-hooks` here -- I did this for our pyproject.toml file in #419, but forgot to update the same pin in our `.pre-commit-config.yaml` file. Doesn't feel like it deserves its own PR :p