### PR TITLE
Move to `hatch-vcs` for versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## Unreleased
+
+* The undocumented `pyi.__version__` and `pyi.PyiTreeChecker.version`
+  attributes has been removed. Use `flake8 --version` from the command line, or
+  `importlib.metadata.version("flake8_pyi")` at runtime, to determine the
+  version of `flake8-pyi` installed at runtime.
+
 ## 23.10.0
 
 * Introduce Y090, which warns if you have an annotation such as `tuple[int]` or

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,8 +51,7 @@ release in January 2022 should be called 22.1.0, followed by 22.1.1.
 
 Releasing a new version is easy:
 
-- Make a PR that updates the version header in `CHANGELOG.md`
-  and the `__version__` attribute in `pyi.py`.
+- Make a PR that updates the version header in `CHANGELOG.md`.
 - Merge the PR and wait for tests to complete.
 - Draft a release using the GitHub UI. The tag name should be
   identical to the version (e.g., `22.1.0`) and the release notes

--- a/pyi.py
+++ b/pyi.py
@@ -37,8 +37,6 @@ if TYPE_CHECKING:
     # and mypy thinks typing_extensions is part of the stdlib.
     from typing_extensions import Literal, TypeAlias, TypeGuard
 
-__version__ = "23.10.0"
-
 LOG = logging.getLogger("flake8.pyi")
 
 if sys.version_info >= (3, 12):
@@ -2005,8 +2003,6 @@ def _check_for_type_comments(lines: list[str]) -> Iterator[Error]:
 @dataclass
 class PyiTreeChecker:
     name: ClassVar[str] = "flake8-pyi"
-    version: ClassVar[str] = __version__
-
     tree: ast.Module
     lines: list[str]
     filename: str = "(none)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
@@ -74,7 +74,10 @@ dev = [
 "flake8.extension" = {Y0 = "pyi:PyiTreeChecker"}
 
 [tool.hatch.version]
-path = "pyi.py"
+source = "vcs"
+
+[tool.hatch.version.raw-options]
+local_scheme = "no-local-version"
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
This means there's one less thing to do manually when cutting a new release. Rather than us manually updating the `__version__` attribute at the top of the `pyi.py` file, `hatch-vcs` looks at the git tag to determine the version that should be added to the metadata when building a wheel.