### PR TITLE
Introduce Y058: Use `(Async)Iterator`, not `(Async)Generator`, for simple `__(a)iter__` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
   version of `flake8-pyi` installed at runtime.
 * Introduce Y058: Use `Iterator` rather than `Generator` as the return value
   for simple `__iter__` methods, and `AsyncIterator` rather than
-  `AsyncGenerator` as the return value for simple `__aiter__` methods. 
+  `AsyncGenerator` as the return value for simple `__aiter__` methods.
 
 ## 23.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
   attributes has been removed. Use `flake8 --version` from the command line, or
   `importlib.metadata.version("flake8_pyi")` at runtime, to determine the
   version of `flake8-pyi` installed at runtime.
+* Introduce Y058: Use `Iterator` rather than `Generator` as the return value
+  for simple `__iter__` methods, and `AsyncIterator` rather than
+  `AsyncGenerator` as the return value for simple `__aiter__` methods. 
 
 ## 23.10.0
 

--- a/ERRORCODES.md
+++ b/ERRORCODES.md
@@ -60,6 +60,7 @@ The following warnings are currently emitted by default:
 | Y055 | Unions of the form `type[X] \| type[Y]` can be simplified to `type[X \| Y]`. Similarly, `Union[type[X], type[Y]]` can be simplified to `type[Union[X, Y]]`.
 | Y056 | Do not call methods such as `.append()`, `.extend()` or `.remove()` on `__all__`. Different type checkers have varying levels of support for calling these methods on `__all__`. Use `+=` instead, which is known to be supported by all major type checkers.
 | Y057 | Do not use `typing.ByteString` or `collections.abc.ByteString`. These types have unclear semantics, and are deprecated; use  `typing_extensions.Buffer` or a union such as `bytes \| bytearray \| memoryview` instead. See [PEP 688](https://peps.python.org/pep-0688/) for more details.
+| Y058 | Use `Iterator` rather than `Generator` as the return value for simple `__iter__` methods, and `AsyncIterator` rather than `AsyncGenerator` as the return value for simple `__aiter__` methods. Using `(Async)Iterator` for these methods is simpler and more elegant, and reflects the fact that the precise kind of iterator returned from an `__iter__` method is usually an implementation detail that could change at any time, and should not be relied upon.
 
 ## Warnings disabled by default
 

--- a/tests/classdefs.pyi
+++ b/tests/classdefs.pyi
@@ -5,7 +5,14 @@ import builtins
 import collections.abc
 import typing
 from abc import abstractmethod
-from collections.abc import AsyncIterable, AsyncIterator, Iterable, Iterator
+from collections.abc import (
+    AsyncGenerator,
+    AsyncIterable,
+    AsyncIterator,
+    Generator,
+    Iterable,
+    Iterator,
+)
 from typing import Any, overload
 
 import typing_extensions
@@ -94,11 +101,29 @@ class BadIterator4(Iterator[int]):
 class IteratorReturningIterable:
     def __iter__(self) -> Iterable[str]: ...  # Y045 "__iter__" methods should return an Iterator, not an Iterable
 
+class IteratorReturningSimpleGenerator1:
+    def __iter__(self) -> Generator: ...  # Y058 Use "Iterator" as the return value for simple "__iter__" methods, e.g. "def __iter__(self) -> Iterator: ..."
+
+class IteratorReturningSimpleGenerator2:
+    def __iter__(self) -> collections.abc.Generator[str, Any, None]: ...  # Y058 Use "Iterator" as the return value for simple "__iter__" methods, e.g. "def __iter__(self) -> Iterator[str]: ..."
+
+class IteratorReturningComplexGenerator:
+    def __iter__(self) -> Generator[str, int, bytes]: ...
+
 class BadAsyncIterator(collections.abc.AsyncIterator[str]):
     def __aiter__(self) -> typing.AsyncIterator[str]: ...  # Y034 "__aiter__" methods in classes like "BadAsyncIterator" usually return "self" at runtime. Consider using "typing_extensions.Self" in "BadAsyncIterator.__aiter__", e.g. "def __aiter__(self) -> Self: ..."  # Y022 Use "collections.abc.AsyncIterator[T]" instead of "typing.AsyncIterator[T]" (PEP 585 syntax)
 
 class AsyncIteratorReturningAsyncIterable:
     def __aiter__(self) -> AsyncIterable[str]: ...  # Y045 "__aiter__" methods should return an AsyncIterator, not an AsyncIterable
+
+class AsyncIteratorReturningSimpleAsyncGenerator1:
+    def __aiter__(self) -> AsyncGenerator: ...  # Y058 Use "AsyncIterator" as the return value for simple "__aiter__" methods, e.g. "def __aiter__(self) -> AsyncIterator: ..."
+
+class AsyncIteratorReturningSimpleAsyncGenerator2:
+    def __aiter__(self) -> collections.abc.AsyncGenerator[str, Any]: ...  # Y058 Use "AsyncIterator" as the return value for simple "__aiter__" methods, e.g. "def __aiter__(self) -> AsyncIterator[str]: ..."
+
+class AsyncIteratorReturningComplexAsyncGenerator:
+    def __aiter__(self) -> AsyncGenerator[str, int]: ...
 
 class Abstract(Iterator[str]):
     @abstractmethod


### PR DESCRIPTION
Closes #423