### PR TITLE
Enforce consistent use of `Literal` and `None`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ New error codes:
 * Introduce Y059: `Generic[]` should always be the last base class, if it is
   present in the bases of a class.
 * Introduce Y060, which flags redundant inheritance from `Generic[]`.
-* Introduce Y061: `None` should not appear inside `Literal[]`, e.g. `Literal["foo", None]`. Use `Literal["foo"] | None` instead.
+* Introduce Y061: Do not use `None` inside a `Literal[]` slice.
+  For example, use `Literal["foo"] | None` instead of `Literal["foo", None]`.
 
 Other changes:
 * The undocumented `pyi.__version__` and `pyi.PyiTreeChecker.version`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ New error codes:
 * Introduce Y059: `Generic[]` should always be the last base class, if it is
   present in the bases of a class.
 * Introduce Y060, which flags redundant inheritance from `Generic[]`.
+* Introduce Y061: `None` should not appear inside `Literal[]`, e.g. `Literal["foo", None]`. Use `Literal["foo"] | None` instead.
 
 Other changes:
 * The undocumented `pyi.__version__` and `pyi.PyiTreeChecker.version`

--- a/ERRORCODES.md
+++ b/ERRORCODES.md
@@ -63,7 +63,7 @@ The following warnings are currently emitted by default:
 | Y058 | Use `Iterator` rather than `Generator` as the return value for simple `__iter__` methods, and `AsyncIterator` rather than `AsyncGenerator` as the return value for simple `__aiter__` methods. Using `(Async)Iterator` for these methods is simpler and more elegant, and reflects the fact that the precise kind of iterator returned from an `__iter__` method is usually an implementation detail that could change at any time, and should not be relied upon.
 | Y059 | `Generic[]` should always be the last base class, if it is present in a class's bases tuple. At runtime, if `Generic[]` is not the final class in a the bases tuple, this [can cause the class creation to fail](https://github.com/python/cpython/issues/106102). In a stub file, however, this rule is enforced purely for stylistic consistency.
 | Y060 | Redundant inheritance from `Generic[]`. For example, `class Foo(Iterable[_T], Generic[_T]): ...` can be written more simply as `class Foo(Iterable[_T]): ...`.<br><br>To avoid false-positive errors, and to avoid complexity in the implementation, this check is deliberately conservative: it only looks at classes that have exactly two bases.
-| Y061 | `None` should not appear inside `Literal[]`, e.g. `Literal["foo", None]`. Use `Literal["foo"] \| None` instead.
+| Y061 | Do not use `None` inside a `Literal[]` slice. For example, use `Literal["foo"] \| None` instead of `Literal["foo", None]`. While both are legal according to [PEP 586](https://peps.python.org/pep-0586/), the former is preferred for stylistic consistency.
 
 ## Warnings disabled by default
 

--- a/ERRORCODES.md
+++ b/ERRORCODES.md
@@ -63,6 +63,7 @@ The following warnings are currently emitted by default:
 | Y058 | Use `Iterator` rather than `Generator` as the return value for simple `__iter__` methods, and `AsyncIterator` rather than `AsyncGenerator` as the return value for simple `__aiter__` methods. Using `(Async)Iterator` for these methods is simpler and more elegant, and reflects the fact that the precise kind of iterator returned from an `__iter__` method is usually an implementation detail that could change at any time, and should not be relied upon.
 | Y059 | `Generic[]` should always be the last base class, if it is present in a class's bases tuple. At runtime, if `Generic[]` is not the final class in a the bases tuple, this [can cause the class creation to fail](https://github.com/python/cpython/issues/106102). In a stub file, however, this rule is enforced purely for stylistic consistency.
 | Y060 | Redundant inheritance from `Generic[]`. For example, `class Foo(Iterable[_T], Generic[_T]): ...` can be written more simply as `class Foo(Iterable[_T]): ...`.<br><br>To avoid false-positive errors, and to avoid complexity in the implementation, this check is deliberately conservative: it only looks at classes that have exactly two bases.
+| Y061 | `None` should not appear inside `Literal[]`, e.g. `Literal["foo", None]`. Use `Literal["foo"] \| None` instead.
 
 ## Warnings disabled by default
 

--- a/pyi.py
+++ b/pyi.py
@@ -1378,20 +1378,12 @@ class PyiVisitor(ast.NodeVisitor):
             for i, elt in enumerate(elts):
                 if _is_None(elt):
                     elts_without_none = elts[:i] + elts[i + 1 :]
-                    slice_without_none = (
-                        elts_without_none[0]
-                        if len(elts_without_none) == 1
-                        else ast.Tuple(elts=elts_without_none)
-                    )
-                    suggestion = unparse(
-                        ast.BinOp(
-                            op=ast.BitOr(),
-                            left=ast.Subscript(
-                                value=node.value, slice=slice_without_none
-                            ),
-                            right=ast.Constant(value=None),
-                        )
-                    )
+                    if len(elts_without_none) == 1:
+                        new_literal_slice = unparse(elts_without_none[0])
+                    else:
+                        new_slice_node = ast.Tuple(elts=elts_without_none)
+                        new_literal_slice = unparse(new_slice_node).strip("()")
+                    suggestion = f"Literal[{new_literal_slice}] | None"
                     self.error(elt, Y061.format(suggestion=suggestion))
                     break  # Only report the first `None`
         self.visit(node.slice)

--- a/pyi.py
+++ b/pyi.py
@@ -1359,7 +1359,7 @@ class PyiVisitor(ast.NodeVisitor):
         self.visit(subscripted_object)
         if subscripted_object_name == "Literal":
             with self.string_literals_allowed.enabled():
-                self.visit(node.slice)
+                self._visit_typing_Literal(node)
             return
 
         if isinstance(node.slice, ast.Tuple):
@@ -1368,6 +1368,33 @@ class PyiVisitor(ast.NodeVisitor):
             self.visit(node.slice)
             if subscripted_object_name in {"tuple", "Tuple"}:
                 self._Y090_error(node)
+
+    def _visit_typing_Literal(self, node: ast.Subscript) -> None:
+        if isinstance(node.slice, ast.Constant) and _is_None(node.slice):
+            # Special case for `Literal[None]`
+            self.error(node.slice, Y061.format(suggestion="None"))
+        elif isinstance(node.slice, ast.Tuple):
+            elts = node.slice.elts
+            for i, elt in enumerate(elts):
+                if _is_None(elt):
+                    elts_without_none = elts[:i] + elts[i + 1 :]
+                    slice_without_none = (
+                        elts_without_none[0]
+                        if len(elts_without_none) == 1
+                        else ast.Tuple(elts=elts_without_none)
+                    )
+                    suggestion = unparse(
+                        ast.BinOp(
+                            op=ast.BitOr(),
+                            left=ast.Subscript(
+                                value=node.value, slice=slice_without_none
+                            ),
+                            right=ast.Constant(value=None),
+                        )
+                    )
+                    self.error(elt, Y061.format(suggestion=suggestion))
+                    break  # Only report the first `None`
+        self.visit(node.slice)
 
     def _visit_slice_tuple(self, node: ast.Tuple, parent: str | None) -> None:
         if parent == "Union":
@@ -2180,6 +2207,7 @@ Y060 = (
     'Y060 Redundant inheritance from "Generic[]"; '
     "class would be inferred as generic anyway"
 )
+Y061 = "Y061 None inside Literal[...] expression. Replace with {suggestion}"
 Y090 = (
     'Y090 "{original}" means '
     '"a tuple of length 1, in which the sole element is of type {typ!r}". '

--- a/pyi.py
+++ b/pyi.py
@@ -2199,7 +2199,7 @@ Y060 = (
     'Y060 Redundant inheritance from "Generic[]"; '
     "class would be inferred as generic anyway"
 )
-Y061 = "Y061 None inside Literal[...] expression. Replace with {suggestion}"
+Y061 = 'Y061 None inside "Literal[]" expression. Replace with "{suggestion}"'
 Y090 = (
     'Y090 "{original}" means '
     '"a tuple of length 1, in which the sole element is of type {typ!r}". '

--- a/tests/literals.pyi
+++ b/tests/literals.pyi
@@ -1,0 +1,6 @@
+from typing import Literal
+
+Literal[None]  # Y061 None inside Literal[...] expression. Replace with None
+Literal[True, None]  # Y061 None inside Literal[...] expression. Replace with Literal[True] | None
+Literal[1, None, "foo"]  # Y061 None inside Literal[...] expression. Replace with Literal[1, 'foo'] | None
+Literal[None, None]  # Y061 None inside Literal[...] expression. Replace with Literal[None] | None

--- a/tests/literals.pyi
+++ b/tests/literals.pyi
@@ -2,5 +2,4 @@ from typing import Literal
 
 Literal[None]  # Y061 None inside "Literal[]" expression. Replace with "None"
 Literal[True, None]  # Y061 None inside "Literal[]" expression. Replace with "Literal[True] | None"
-Literal[1, None, "foo"]  # Y061 None inside "Literal[]" expression. Replace with "Literal[1, 'foo'] | None"
-Literal[None, None]  # Y061 None inside "Literal[]" expression. Replace with "Literal[None] | None"
+Literal[1, None, "foo", None]  # Y061 None inside "Literal[]" expression. Replace with "Literal[1, 'foo', None] | None"

--- a/tests/literals.pyi
+++ b/tests/literals.pyi
@@ -1,6 +1,6 @@
 from typing import Literal
 
-Literal[None]  # Y061 None inside Literal[...] expression. Replace with None
-Literal[True, None]  # Y061 None inside Literal[...] expression. Replace with Literal[True] | None
-Literal[1, None, "foo"]  # Y061 None inside Literal[...] expression. Replace with Literal[1, 'foo'] | None
-Literal[None, None]  # Y061 None inside Literal[...] expression. Replace with Literal[None] | None
+Literal[None]  # Y061 None inside "Literal[]" expression. Replace with "None"
+Literal[True, None]  # Y061 None inside "Literal[]" expression. Replace with "Literal[True] | None"
+Literal[1, None, "foo"]  # Y061 None inside "Literal[]" expression. Replace with "Literal[1, 'foo'] | None"
+Literal[None, None]  # Y061 None inside "Literal[]" expression. Replace with "Literal[None] | None"


### PR DESCRIPTION
Closes #424

I wrote the first version using match-case but then I realized that's only for python >=3.10 :sweat_smile: :sob: 

I'd be happy for feedback! Some notes:

- I don't handle `Optional[Literal["foo"]]` since we already have a check for the use of `Optional[...]` in general
- I'm not sure if we want a custom message specifically for `Literal[None] -> None`, currently I use the same message for this case and for cases with multiple values
- If there are multiple `None` values e.g. `Literal[None, "foo", None]`, I only report the first. It would be easy enough to collect all of them but then I wasn't sure which node to report (i.e. which part of the source gets the squiggly red line - currently it's the first `None`). There could even a more general rule which checks for duplicates inside `Literal[...]` analogous to the one for unions
