### PR TITLE
Flag `typing_extensions.Text` with Y039, not Y023

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Other changes:
   for metaclasses. While reliably determining whether a class is a metaclass in
   all cases would be impossible for flake8-pyi, the new heuristics should
   reduce the number of false positives from this check.
+* Attempting to import `typing_extensions.Text` now causes Y039 to be emitted
+  rather than Y023.
 
 ## 23.10.0
 

--- a/ERRORCODES.md
+++ b/ERRORCODES.md
@@ -41,7 +41,7 @@ The following warnings are currently emitted by default:
 | Y036 | Y036 detects common errors in `__exit__` and `__aexit__` methods. For example, the first argument in an `__exit__` method should either be annotated with `object`, `_typeshed.Unused` (a special alias for `object`) or `type[BaseException] \| None`.
 | Y037 | Use PEP 604 syntax instead of `typing(_extensions).Union` and `typing(_extensions).Optional`. E.g. use `str \| int` instead of `Union[str, int]`, and use `str \| None` instead of `Optional[str]`.
 | Y038 | Use `from collections.abc import Set as AbstractSet` instead of `from typing import AbstractSet` or `from typing_extensions import AbstractSet`.
-| Y039 | Use `str` instead of `typing.Text`.
+| Y039 | Use `str` instead of `typing.Text` or `typing_extensions.Text`.
 | Y040 | Never explicitly inherit from `object`, as all classes implicitly inherit from `object` in Python 3.
 | Y041 | Y041 detects redundant numeric unions in the context of parameter annotations. For example, PEP 484 specifies that type checkers should allow `int` objects to be passed to a function, even if the function states that it accepts a `float`. As such, `int` is redundant in the union `int \| float` in the context of a parameter annotation. In the same way, `int` is sometimes redundant in the union `int \| complex`, and `float` is sometimes redundant in the union `float \| complex`.
 | Y042 | Type alias names should use CamelCase rather than snake_case.

--- a/pyi.py
+++ b/pyi.py
@@ -129,11 +129,13 @@ _BAD_TYPINGEXTENSIONS_Y023_IMPORTS = frozenset(
         "runtime_checkable",
         "NewType",
         "overload",
-        "Text",
         "NoReturn",
         # ClassVar deliberately omitted,
         # as it's the only one in this group that should be parameterised.
         # It is special-cased elsewhere.
+        #
+        # Text is also deliberately omitted,
+        # as you shouldn't be importing it from anywhere! (Y039)
     }
 )
 
@@ -942,6 +944,10 @@ class PyiVisitor(ast.NodeVisitor):
                 old_syntax=fullname, example='"int | str" instead of "Union[int, str]"'
             )
 
+        # Y039 errors
+        elif module_name in _TYPING_MODULES and object_name == "Text":
+            error_message = Y039.format(module=module_name)
+
         # Y023 errors
         elif module_name == "typing_extensions":
             if object_name in _BAD_TYPINGEXTENSIONS_Y023_IMPORTS:
@@ -960,10 +966,6 @@ class PyiVisitor(ast.NodeVisitor):
         # Y024 errors
         elif fullname == "collections.namedtuple":
             error_message = Y024
-
-        # Y039 errors
-        elif fullname == "typing.Text":
-            error_message = Y039
 
         else:
             return
@@ -2185,7 +2187,7 @@ Y038 = (
     'Y038 Use "from collections.abc import Set as AbstractSet" '
     'instead of "from {module} import AbstractSet" (PEP 585 syntax)'
 )
-Y039 = 'Y039 Use "str" instead of "typing.Text"'
+Y039 = 'Y039 Use "str" instead of "{module}.Text"'
 Y040 = 'Y040 Do not inherit from "object" explicitly, as it is redundant in Python 3'
 Y041 = (
     'Y041 Use "{implicit_supertype}" '

--- a/tests/imports.pyi
+++ b/tests/imports.pyi
@@ -149,6 +149,7 @@ from collections.abc import Set  # Y025 Use "from collections.abc import Set as 
 from typing import AbstractSet  # Y038 Use "from collections.abc import Set as AbstractSet" instead of "from typing import AbstractSet" (PEP 585 syntax)
 from typing_extensions import AbstractSet  # Y038 Use "from collections.abc import Set as AbstractSet" instead of "from typing_extensions import AbstractSet" (PEP 585 syntax)
 from typing import Text  # Y039 Use "str" instead of "typing.Text"
+from typing_extensions import Text  # Y039 Use "str" instead of "typing_extensions.Text"
 from typing import ByteString  # Y057 Do not use typing.ByteString, which has unclear semantics and is deprecated
 from collections.abc import ByteString  # Y057 Do not use collections.abc.ByteString, which has unclear semantics and is deprecated
 


### PR DESCRIPTION
This is a minor change, but I think it's more consistent to flag this with Y039 rather than Y023. Otherwise we're telling people to use `typing.Text` rather than `typing_extensions.Text` via Y023, and then when they do so, we immediately complain at them to not use `Text` at all (via Y039)