### PR TITLE
Improve the error message in a Y061 edge case

### DIFF
--- a/pyi.py
+++ b/pyi.py
@@ -1432,7 +1432,9 @@ class PyiVisitor(ast.NodeVisitor):
             elts = node.slice.elts
             for i, elt in enumerate(elts):
                 if _is_None(elt):
-                    elts_without_none = elts[:i] + elts[i + 1 :]
+                    elts_without_none = elts[:i] + [
+                        elt for elt in elts[i + 1 :] if not _is_None(elt)
+                    ]
                     if len(elts_without_none) == 1:
                         new_literal_slice = unparse(elts_without_none[0])
                     else:

--- a/tests/literals.pyi
+++ b/tests/literals.pyi
@@ -2,4 +2,4 @@ from typing import Literal
 
 Literal[None]  # Y061 None inside "Literal[]" expression. Replace with "None"
 Literal[True, None]  # Y061 None inside "Literal[]" expression. Replace with "Literal[True] | None"
-Literal[1, None, "foo", None]  # Y061 None inside "Literal[]" expression. Replace with "Literal[1, 'foo', None] | None"
+Literal[1, None, "foo", None]  # Y061 None inside "Literal[]" expression. Replace with "Literal[1, 'foo'] | None"


### PR DESCRIPTION
Currently we're recommending code that we'd immediately complain about if the user actually used it. We shouldn't do that. Possibly we could introduce another error code emitting an error for duplicate `Literal` members, but for now I'd just like to fix the Y061 error message.