### PR TITLE
Bump various test dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: check-merge-conflict
       - id: mixed-line-ending
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 23.12.0 # must match pyproject.toml
+    rev: 23.12.1 # must match pyproject.toml
     hooks:
       - id: black
         language_version: python3.8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,12 +9,12 @@ repos:
       - id: check-merge-conflict
       - id: mixed-line-ending
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 23.11.0 # must match pyproject.toml
+    rev: 23.12.0 # must match pyproject.toml
     hooks:
       - id: black
         language_version: python3.8
   - repo: https://github.com/pycqa/isort
-    rev: 5.12.0 # must match pyproject.toml
+    rev: 5.13.2 # must match pyproject.toml
     hooks:
       - id: isort
         name: isort (python)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,11 +60,11 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "black==23.11.0",           # Must match .pre-commit-config.yaml
-    "flake8-bugbear==23.9.16",
+    "black==23.12.0",           # Must match .pre-commit-config.yaml
+    "flake8-bugbear==23.12.2",
     "flake8-noqa==1.3.2",
-    "isort==5.12.0",            # Must match .pre-commit-config.yaml
-    "mypy==1.7.1",
+    "isort==5.13.2",            # Must match .pre-commit-config.yaml
+    "mypy==1.8.0",
     "pre-commit-hooks==4.5.0",  # Must match .pre-commit-config.yaml
     "pytest==7.4.3",
     "pytest-xdist==3.5.0",
@@ -73,6 +73,9 @@ dev = [
 
 [project.entry-points]
 "flake8.extension" = {Y0 = "pyi:PyiTreeChecker"}
+
+[tool.hatch.build.targets.wheel]
+include = ["pyi.py"]
 
 [tool.hatch.version]
 source = "vcs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "black==23.12.0",           # Must match .pre-commit-config.yaml
+    "black==23.12.1",           # Must match .pre-commit-config.yaml
     "flake8-bugbear==23.12.2",
     "flake8-noqa==1.3.2",
     "isort==5.13.2",            # Must match .pre-commit-config.yaml


### PR DESCRIPTION
And fix editable installs, which have apparently been broken for us since the backwards-incompatible change to hatchling discussed in https://github.com/pypa/hatch/issues/1113