### PR TITLE
Use uv for installing dependencies in CI on Linux-only workflows

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -36,10 +36,9 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-          cache: pip
-          cache-dependency-path: pyproject.toml
           allow-prereleases: true
-      - run: pip install -e .[dev]
+      - run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - run: uv pip install -e .[dev] --system
       - run: mypy
 
   flake8:
@@ -50,10 +49,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
-          cache: pip
-          cache-dependency-path: pyproject.toml
-      - run: pip install -e .[dev]
+          python-version: "3.12"
+      - run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - run: uv pip install -e .[dev] --system
       - run: |
           flake8 $(git ls-files | grep 'py$') --color always
 
@@ -72,7 +70,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
-          cache: pip
-          cache-dependency-path: pyproject.toml
-      - run: pip install -e .[dev]
+      - name: Install uv (Windows)
+        if: ${{ runner.os == 'Windows' }}
+        run: irm https://astral.sh/uv/install.ps1 | iex
+      - name: Install uv (Unix)
+        if: ${{ runner.os != 'Windows' }}
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - run: uv pip install -e .[dev] --system
       - run: python3 -m pytest -vv

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -70,11 +70,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
-      - name: Install uv (Windows)
-        if: ${{ runner.os == 'Windows' }}
-        run: irm https://astral.sh/uv/install.ps1 | iex
-      - name: Install uv (Unix)
-        if: ${{ runner.os != 'Windows' }}
-        run: curl -LsSf https://astral.sh/uv/install.sh | sh
-      - run: uv pip install -e .[dev] --system
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - run: pip install -e .[dev]
       - run: python3 -m pytest -vv

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.12"
       - name: Install pypa/build
         run: >-
           python -m

--- a/.github/workflows/typeshed_primer.yml
+++ b/.github/workflows/typeshed_primer.yml
@@ -39,21 +39,21 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
-          cache: pip
-          cache-dependency-path: new_plugin/pyproject.toml
-      - run: pip install flake8-noqa
+          python-version: "3.12"
+      - name: Install uv
+        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - run: uv pip install flake8-noqa --system
       # We cd so that "old_plugin"/"new_plugin"/typeshed" don't appear in the error path
       - name: flake8 typeshed using target branch
         run: |
           cd old_plugin
-          pip install -e .
+          uv pip install -e . --system
           cd ../typeshed
           flake8 --exit-zero --color never --output-file ../old_errors.txt
       - name: flake8 typeshed using PR branch
         run: |
           cd new_plugin
-          pip install -e .
+          uv pip install -e . --system
           cd ../typeshed
           flake8 --exit-zero --color never --output-file ../new_errors.txt
       - name: Get diff between the two runs


### PR DESCRIPTION
It's currently taking 24s to install dependencies on Windows in CI, and only 7s to actually run the tests when the dependencies have been installed.

Also, bump a few Python versions in our workflow files, while we're at it.