### PR TITLE
New rule: prefer `x: Final = 42` over `x: Final[Literal[42]]`

### DIFF
--- a/ERRORCODES.md
+++ b/ERRORCODES.md
@@ -77,6 +77,7 @@ The following warnings are currently emitted by default:
 | Y061 | Do not use `None` inside a `Literal[]` slice. For example, use `Literal["foo"] \| None` instead of `Literal["foo", None]`. While both are legal according to [PEP 586](https://peps.python.org/pep-0586/), the former is preferred for stylistic consistency. Note that this warning is not emitted if Y062 is emitted for the same `Literal[]` slice. For example, `Literal[None, None, True, True]` only causes Y062 to be emitted. | Style
 | Y062 | `Literal[]` slices shouldn't contain duplicates, e.g. `Literal[True, True]` is not allowed. | Redundant code
 | Y063 | Use [PEP 570 syntax](https://peps.python.org/pep-0570/) (e.g. `def foo(x: int, /) -> None: ...`) to denote positional-only arguments, rather than [the older Python 3.7-compatible syntax described in PEP 484](https://peps.python.org/pep-0484/#positional-only-arguments) (`def foo(__x: int) -> None: ...`, etc.). | Style
+| Y064 | Use simpler syntax to define final literal types. For example, use `x: Final = 42` instead of `x: Final[Literal[42]]`. | Style
 
 ## Warnings disabled by default
 

--- a/tests/literals.pyi
+++ b/tests/literals.pyi
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Final, Literal
 
 Literal[None]  # Y061 None inside "Literal[]" expression. Replace with "None"
 Literal[True, None]  # Y061 None inside "Literal[]" expression. Replace with "Literal[True] | None"
@@ -21,3 +21,8 @@ Literal[1, None, "foo", None]  # Y061 None inside "Literal[]" expression. Replac
 # and there are no None members in the Literal[] slice,
 # only emit Y062:
 Literal[None, True, None, True]  # Y062 Duplicate "Literal[]" member "True"
+
+x: Final[Literal[True]]  # Y064 Use "x: Final = True" instead of "x: Final[Literal[True]]"
+# If Y061 and Y064 both apply, only emit Y064
+y: Final[Literal[None]]  # Y064 Use "y: Final = None" instead of "y: Final[Literal[None]]"
+z: Final[Literal[True, False]]


### PR DESCRIPTION
closes #468 

Here it goes :)

There is an interaction between this new rule (`Y064`) and `Y061` (which warns for `Literal[None]`) where it's not entirely clear to me what to do. For example, in this case:

```python
x: Final[Literal[None]]
```

you'd get both `Y064` and `Y061`. I think in this case turning it into `x: Final = None` is probably nicer so I decided to not emit `Y061` if `Y064` would also be emitted.

On the other hand, this seems like a pretty unusual case (no examples in typeshed) so maybe it's not needed?

