### PR TITLE
Sync pyproject.toml pins with pre-commit pins

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,13 +60,13 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "black==24.1.1",            # Must match .pre-commit-config.yaml
-    "flake8-bugbear==24.1.17",
+    "black==24.3.0",            # Must match .pre-commit-config.yaml
+    "flake8-bugbear==24.2.6",
     "flake8-noqa==1.4.0",
     "isort==5.13.2",            # Must match .pre-commit-config.yaml
-    "mypy==1.8.0",
+    "mypy==1.9.0",
     "pre-commit-hooks==4.5.0",  # Must match .pre-commit-config.yaml
-    "pytest==8.0.0",
+    "pytest==8.1.1",
     "pytest-xdist==3.5.0",
     "types-pyflakes<4",
 ]


### PR DESCRIPTION
The black pin got out of sync in #476. Bump a few more test deps while we're about it.