### PR TITLE
Allow simple assignments to `None` in enum class scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## Unreleased
+
+Bugfixes:
+* Fix Y026 false positive: allow simple assignment to `None` in class scopes
+  if the class is known to be an enum class.
+
 ## 24.3.1
 
 New error codes:

--- a/pyi.py
+++ b/pyi.py
@@ -1219,7 +1219,7 @@ class PyiVisitor(ast.NodeVisitor):
             isinstance(assignment, ast.Subscript)
             or _is_valid_pep_604_union(assignment)
             or _is_Any(assignment)
-            or _is_None(assignment)
+            or (_is_None(assignment) and not self.visiting_enum_class)
         ):
             new_node = ast.AnnAssign(
                 target=target,

--- a/tests/aliases.pyi
+++ b/tests/aliases.pyi
@@ -2,6 +2,7 @@
 import array
 import builtins
 import collections.abc
+import enum
 import typing
 from collections.abc import Mapping
 from typing import (
@@ -86,3 +87,6 @@ _snake_case_alias2: TypeAlias = Literal["whatever"]  # Y042 Type aliases should 
 
 # check that this edge case doesn't crash the plugin
 _: TypeAlias = str | int
+
+class FooEnum(enum.Enum):
+    BAR = None  # shouldn't emit Y026 because it's an assignment in an enum class


### PR DESCRIPTION
Fixes a false positive in `uuid.pyi` currently showing up in CI for https://github.com/python/typeshed/pull/11299