### PR TITLE
Fix typeshed_primer workflow

### DIFF
--- a/.github/workflows/typeshed_primer.yml
+++ b/.github/workflows/typeshed_primer.yml
@@ -53,7 +53,7 @@ jobs:
       - name: flake8 typeshed using PR branch
         run: |
           cd new_plugin
-          uv pip install -e . --system
+          uv pip install -e . --system --reinstall
           cd ../typeshed
           flake8 --exit-zero --color never --output-file ../new_errors.txt
       - name: Get diff between the two runs


### PR DESCRIPTION
It's been broken since we switched the workflow to use `uv`, because `uv` doesn't (by default) reinstall an editable package if it sees that it's already installed with the "right version". (I personally find this pretty surprising behaviour for editable installs. It's already tracked in https://github.com/astral-sh/uv/issues/2844.) That meant that we were just running the same version of flake8-pyi in the two runs, which meant that of course the diff between the two runs was always just 0 lines.