### PR TITLE
Use newer uv features to simplify some CI jobs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           version: "latest"
       - run: |
-          uv run --python=3.12 --extra=-dev flake8 $(git ls-files | grep 'py$') --color=always
+          uv run --python=3.12 --extra=dev flake8 $(git ls-files | grep 'py$') --color=always
 
   tests:
     name: pytest suite

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           version: "latest"
       - run: |
-          uv run --python 3.12 --extra dev mypy --python-version=${{ matrix.python-version }}
+          uv run --python=3.12 --extra=dev mypy --python-version=${{ matrix.python-version }}
 
   flake8:
     name: flake8
@@ -49,7 +49,7 @@ jobs:
         with:
           version: "latest"
       - run: |
-          uv run --python 3.12 --extra dev flake8 $(git ls-files | grep 'py$') --color always
+          uv run --python=3.12 --extra=-dev flake8 $(git ls-files | grep 'py$') --color=always
 
   tests:
     name: pytest suite
@@ -66,4 +66,4 @@ jobs:
         with:
           version: "latest"
       - run: |
-          uv run --python ${{ matrix.python-version }} --extra dev pytest -vv
+          uv run --python=${{ matrix.python-version }} --extra=dev pytest -vv

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -33,13 +33,11 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v1
         with:
-          python-version: "3.12"
-          allow-prereleases: true
-      - run: curl -LsSf https://astral.sh/uv/install.sh | sh
-      - run: uv pip install -e .[dev] --system
-      - run: mypy --python-version=${{ matrix.python-version }}
+          version: "latest"
+      - run: |
+          uv run --python 3.12 --extra dev mypy --python-version=${{ matrix.python-version }}
 
   flake8:
     name: flake8
@@ -47,13 +45,11 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v1
         with:
-          python-version: "3.12"
-      - run: curl -LsSf https://astral.sh/uv/install.sh | sh
-      - run: uv pip install -e .[dev] --system
+          version: "latest"
       - run: |
-          flake8 $(git ls-files | grep 'py$') --color always
+          uv run --python 3.12 --extra dev flake8 $(git ls-files | grep 'py$') --color always
 
   tests:
     name: pytest suite
@@ -66,11 +62,8 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: astral-sh/setup-uv@v1
         with:
-          python-version: ${{ matrix.python-version }}
-          allow-prereleases: true
-          cache: pip
-          cache-dependency-path: pyproject.toml
-      - run: pip install -e .[dev]
-      - run: python3 -m pytest -vv
+          version: "latest"
+      - run: |
+          uv run --python ${{ matrix.python-version }} --extra dev pytest -vv


### PR DESCRIPTION
- Install uv using the new GitHub action rather than `curl`
- Remove the step installing Python: uv will now install Python itself if Python isn't already installed (using the `--python` flag to `uv run`)

A (subjective) downside of using `uv run` to run these commands in CI is that if you just copy-and-paste the commands from the GitHub workflow and run them locally, it creates a `uv.lock` file (so you have a dirty commit history). I don't really feel like we particularly need a lockfile for this project -- it feels like it would just add complications without really giving us anything -- so I'm not sure I'd want to commit a `uv.lock` file into this repo. (Others might feel differently.)