### PR TITLE
switch to using dependency groups for dev-dependencies

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           version: "latest"
       - run: |
-          uv run --python=3.12 --extra=dev mypy --python-version=${{ matrix.python-version }}
+          uv run --python=3.12 --group=dev mypy --python-version=${{ matrix.python-version }}
 
   flake8:
     name: flake8
@@ -49,7 +49,7 @@ jobs:
         with:
           version: "latest"
       - run: |
-          uv run --python=3.12 --extra=dev flake8 $(git ls-files | grep 'py$') --color=always
+          uv run --python=3.12 --group=dev flake8 $(git ls-files | grep 'py$') --color=always
 
   tests:
     name: pytest suite
@@ -66,4 +66,4 @@ jobs:
         with:
           version: "latest"
       - run: |
-          uv run --python=${{ matrix.python-version }} --extra=dev pytest -vv
+          uv run --python=${{ matrix.python-version }} --group=dev pytest -vv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ New error codes:
 Other changes:
 * Y011/Y015 will now allow all defaults that include an attribute access,
   for example `math.inf` or enum members.
+* Development-only dependencies are now declared using
+  [dependency groups](https://packaging.python.org/en/latest/specifications/dependency-groups/)
+  rather than
+  [optional dependencies](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#dependencies-and-requirements).
 
 ## 24.9.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,13 +50,7 @@ dependencies = [
     "pyflakes >= 2.1.1",
 ]
 
-[project.urls]
-"Homepage" = "https://github.com/PyCQA/flake8-pyi"
-"Source" = "https://github.com/PyCQA/flake8-pyi"
-"Bug Tracker" = "https://github.com/PyCQA/flake8-pyi/issues"
-"Changelog" = "https://github.com/PyCQA/flake8-pyi/blob/main/CHANGELOG.md"
-
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
     "black==25.1.0",            # Must match .pre-commit-config.yaml
     "flake8-bugbear==24.12.12",
@@ -68,6 +62,12 @@ dev = [
     "pytest-xdist==3.6.1",
     "types-pyflakes<4",
 ]
+
+[project.urls]
+"Homepage" = "https://github.com/PyCQA/flake8-pyi"
+"Source" = "https://github.com/PyCQA/flake8-pyi"
+"Bug Tracker" = "https://github.com/PyCQA/flake8-pyi/issues"
+"Changelog" = "https://github.com/PyCQA/flake8-pyi/blob/main/CHANGELOG.md"
 
 [project.entry-points]
 "flake8.extension" = {Y0 = "pyi:PyiTreeChecker"}


### PR DESCRIPTION
These are now the recommended way to list dev-dependencies in a pyproject.toml file. They are now supported by both pip and uv, which share a common interface for installing them.

Spec: https://packaging.python.org/en/latest/specifications/dependency-groups/