### PR TITLE
gitignore uv.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,5 +69,5 @@ target/
 # IDEs
 .vscode/
 
-# Probably more complexity than it's worth for this repo?
+# Currently more complexity than it's worth for this repo.
 uv.lock


### PR DESCRIPTION
uv adds a `uv.lock` file if you run any uv commands locally in a repository. But I've never felt the need for a lockfile for this repo; maintaining it would add more complexity than it's worth for us IMO. This PR gitignores it.