### PR TITLE
Prepare release 25.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## Unreleased
+## 5.5.0
 
 New error codes:
 * Introduce Y067: Don't use `Incomplete | None = None`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ however, we advise setting up a virtual environment first:
 
     $ python3 -m venv env
     $ source env/bin/activate
-    $ pip install -e --group=dev
+    $ pip install -e . --group=dev
 
 To format your code with `isort` and `black`, run:
 


### PR DESCRIPTION
It's been a while since the last one, we've added two new error codes, and we've made several other significant changes such as switching to a package structure