### PR TITLE
Recommend to use `typing.TypeAlias`, not `typing_extensions.TypeAlias`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ flake8-pyi uses Calendar Versioning (CalVer).
 ### Other changes
 
 * Support Python 3.15.
+* Recommend to use `typing.TypeAlias` instead of `typing_extensions.TypeAlias`.
 
 ## 26.5.0
 

--- a/flake8_pyi/errors.py
+++ b/flake8_pyi/errors.py
@@ -48,7 +48,7 @@ Y025 = (
     'Y025 Use "from collections.abc import Set as AbstractSet" '
     'to avoid confusion with "builtins.set"'
 )
-Y026 = 'Y026 Use typing_extensions.TypeAlias for type aliases, e.g. "{suggestion}"'
+Y026 = 'Y026 Use typing.TypeAlias for type aliases, e.g. "{suggestion}"'
 Y028 = "Y028 Use class-based syntax for NamedTuples"
 Y029 = "Y029 Defining __repr__ or __str__ in a stub is almost always redundant"
 Y030 = "Y030 Multiple Literal members in a union. {suggestion}"

--- a/tests/aliases.pyi
+++ b/tests/aliases.pyi
@@ -23,34 +23,34 @@ import typing_extensions
 class Foo:
     def baz(self) -> None: ...
 
-StringMapping = Mapping[str, str]  # Y026 Use typing_extensions.TypeAlias for type aliases, e.g. "StringMapping: TypeAlias = Mapping[str, str]"
-IntSequence = collections.abc.Sequence[int]  # Y026 Use typing_extensions.TypeAlias for type aliases, e.g. "IntSequence: TypeAlias = collections.abc.Sequence[int]"
-IntArray = array.array[int]  # Y026 Use typing_extensions.TypeAlias for type aliases, e.g. "IntArray: TypeAlias = array.array[int]"
-FooWeakDict = WeakValueDictionary[str, Foo]  # Y026 Use typing_extensions.TypeAlias for type aliases, e.g. "FooWeakDict: TypeAlias = WeakValueDictionary[str, Foo]"
-P = builtins.tuple[int, int]  # Y026 Use typing_extensions.TypeAlias for type aliases, e.g. "P: TypeAlias = builtins.tuple[int, int]"
-Q = tuple[int, int]  # Y026 Use typing_extensions.TypeAlias for type aliases, e.g. "Q: TypeAlias = tuple[int, int]"
-R = Any  # Y026 Use typing_extensions.TypeAlias for type aliases, e.g. "R: TypeAlias = Any"
-S = Optional[str]  # Y026 Use typing_extensions.TypeAlias for type aliases, e.g. "S: TypeAlias = Optional[str]"
-T = Annotated[int, "some very useful metadata"]  # Y026 Use typing_extensions.TypeAlias for type aliases, e.g. "T: TypeAlias = Annotated[int, 'some very useful metadata']"
-U = typing.Literal["ham", "bacon"]  # Y026 Use typing_extensions.TypeAlias for type aliases, e.g. "U: TypeAlias = typing.Literal['ham', 'bacon']"
-V = Literal["[(", ")]"]  # Y026 Use typing_extensions.TypeAlias for type aliases, e.g. "V: TypeAlias = Literal['[(', ')]']"
-X = typing_extensions.Literal["foo", "bar"]  # Y026 Use typing_extensions.TypeAlias for type aliases, e.g. "X: TypeAlias = typing_extensions.Literal['foo', 'bar']"  # Y023 Use "typing.Literal" instead of "typing_extensions.Literal"
-Y = int | str  # Y026 Use typing_extensions.TypeAlias for type aliases, e.g. "Y: TypeAlias = int | str"
-Z = Union[str, bytes]  # Y026 Use typing_extensions.TypeAlias for type aliases, e.g. "Z: TypeAlias = Union[str, bytes]"
-ZZ = None  # Y026 Use typing_extensions.TypeAlias for type aliases, e.g. "ZZ: TypeAlias = None"
+StringMapping = Mapping[str, str]  # Y026 Use typing.TypeAlias for type aliases, e.g. "StringMapping: TypeAlias = Mapping[str, str]"
+IntSequence = collections.abc.Sequence[int]  # Y026 Use typing.TypeAlias for type aliases, e.g. "IntSequence: TypeAlias = collections.abc.Sequence[int]"
+IntArray = array.array[int]  # Y026 Use typing.TypeAlias for type aliases, e.g. "IntArray: TypeAlias = array.array[int]"
+FooWeakDict = WeakValueDictionary[str, Foo]  # Y026 Use typing.TypeAlias for type aliases, e.g. "FooWeakDict: TypeAlias = WeakValueDictionary[str, Foo]"
+P = builtins.tuple[int, int]  # Y026 Use typing.TypeAlias for type aliases, e.g. "P: TypeAlias = builtins.tuple[int, int]"
+Q = tuple[int, int]  # Y026 Use typing.TypeAlias for type aliases, e.g. "Q: TypeAlias = tuple[int, int]"
+R = Any  # Y026 Use typing.TypeAlias for type aliases, e.g. "R: TypeAlias = Any"
+S = Optional[str]  # Y026 Use typing.TypeAlias for type aliases, e.g. "S: TypeAlias = Optional[str]"
+T = Annotated[int, "some very useful metadata"]  # Y026 Use typing.TypeAlias for type aliases, e.g. "T: TypeAlias = Annotated[int, 'some very useful metadata']"
+U = typing.Literal["ham", "bacon"]  # Y026 Use typing.TypeAlias for type aliases, e.g. "U: TypeAlias = typing.Literal['ham', 'bacon']"
+V = Literal["[(", ")]"]  # Y026 Use typing.TypeAlias for type aliases, e.g. "V: TypeAlias = Literal['[(', ')]']"
+X = typing_extensions.Literal["foo", "bar"]  # Y026 Use typing.TypeAlias for type aliases, e.g. "X: TypeAlias = typing_extensions.Literal['foo', 'bar']"  # Y023 Use "typing.Literal" instead of "typing_extensions.Literal"
+Y = int | str  # Y026 Use typing.TypeAlias for type aliases, e.g. "Y: TypeAlias = int | str"
+Z = Union[str, bytes]  # Y026 Use typing.TypeAlias for type aliases, e.g. "Z: TypeAlias = Union[str, bytes]"
+ZZ = None  # Y026 Use typing.TypeAlias for type aliases, e.g. "ZZ: TypeAlias = None"
 
 StringMapping: TypeAlias = Mapping[str, str]
 IntSequence: TypeAlias = collections.abc.Sequence[int]
 IntArray: TypeAlias = array.array[int]
 FooWeakDict: TypeAlias = WeakValueDictionary[str, Foo]
 A: typing.TypeAlias = typing.Literal["ham", "bacon"]
-B: typing_extensions.TypeAlias = Literal["spam", "eggs"]
+B: typing.TypeAlias = Literal["spam", "eggs"]
 C: TypeAlias = typing_extensions.Literal["foo", "bar"]  # Y023 Use "typing.Literal" instead of "typing_extensions.Literal"
 D: TypeAlias = int | str
 E: TypeAlias = Union[str, bytes]
 F: TypeAlias = int
 G: typing.TypeAlias = int
-H: typing_extensions.TypeAlias = int
+H: typing.TypeAlias = int
 I: TypeAlias = Annotated[int, "some very useful metadata"]
 J: TypeAlias = Optional[str]
 K: TypeAlias = Any

--- a/tests/attribute_annotations.pyi
+++ b/tests/attribute_annotations.pyi
@@ -28,7 +28,7 @@ field82: float = -98.43
 field83 = -42j  # Y052 Need type annotation for "field83"
 field84 = 5 + 42j  # Y052 Need type annotation for "field84"
 field85 = -5 - 42j  # Y052 Need type annotation for "field85"
-field9 = None  # Y026 Use typing_extensions.TypeAlias for type aliases, e.g. "field9: TypeAlias = None"
+field9 = None  # Y026 Use typing.TypeAlias for type aliases, e.g. "field9: TypeAlias = None"
 Field95: TypeAlias = None
 Field96: TypeAlias = int | None
 Field97: TypeAlias = None | typing.SupportsInt | builtins.str | float | bool

--- a/tests/imports.pyi
+++ b/tests/imports.pyi
@@ -46,6 +46,7 @@ from typing import (
     Final,
     Generic,
     Protocol,
+    TypeAlias,
     TypeVar,
     SupportsAbs,
     SupportsBytes,
@@ -69,7 +70,6 @@ from typing import (
 from typing_extensions import (
     Concatenate,
     ParamSpec,
-    TypeAlias,
     TypeGuard,
     Annotated,
 )

--- a/tests/incomplete.pyi
+++ b/tests/incomplete.pyi
@@ -1,5 +1,5 @@
 from _typeshed import Incomplete
-from typing_extensions import TypeAlias
+from typing import TypeAlias
 
 IncompleteAlias: TypeAlias = Incomplete  # ok
 

--- a/tests/incomplete.pyi
+++ b/tests/incomplete.pyi
@@ -1,5 +1,6 @@
-from _typeshed import Incomplete
 from typing import TypeAlias
+
+from _typeshed import Incomplete
 
 IncompleteAlias: TypeAlias = Incomplete  # ok
 

--- a/tests/union_duplicates.pyi
+++ b/tests/union_duplicates.pyi
@@ -83,7 +83,7 @@ class Four:
     var: builtins.bool | Literal[True]  # Y051 "Literal[True]" is redundant in a union with "bool"
 
 DupesHereSoNoY051: TypeAlias = int | int | Literal[42]  # Y016 Duplicate union member "int"
-NightmareAlias1 = int | float | Literal[4, b"bar"] | Literal["foo"]  # Y026 Use typing_extensions.TypeAlias for type aliases, e.g. "NightmareAlias1: TypeAlias = int | float | Literal[4, b'bar'] | Literal['foo']"  # Y030 Multiple Literal members in a union. Combine them into one, e.g. "Literal[4, b'bar', 'foo']".  # Y051 "Literal[4]" is redundant in a union with "int"
+NightmareAlias1 = int | float | Literal[4, b"bar"] | Literal["foo"]  # Y026 Use typing.TypeAlias for type aliases, e.g. "NightmareAlias1: TypeAlias = int | float | Literal[4, b'bar'] | Literal['foo']"  # Y030 Multiple Literal members in a union. Combine them into one, e.g. "Literal[4, b'bar', 'foo']".  # Y051 "Literal[4]" is redundant in a union with "int"
 nightmare_alias2: TypeAlias = int | float | Literal[True, 4] | Literal["foo"]  # Y042 Type aliases should use the CamelCase naming convention  # Y030 Multiple Literal members in a union. Combine them into one, e.g. "Literal[True, 4, 'foo']".  # Y051 "Literal[4]" is redundant in a union with "int"
 DoublyNestedAlias: TypeAlias = Union[type[str], type[float] | type[bytes]]  # Y055 Multiple "type[Foo]" members in a union. Combine them into one, e.g. "type[float | bytes]".
 # typing.Type and typing_extensions.Type are intentionally excluded from Y055


### PR DESCRIPTION
`typing.TypeAlias` was added in Python 3.10, which is the oldest version we support.